### PR TITLE
Duplicated file types error clarification

### DIFF
--- a/man/multiqc_parse_plots.Rd
+++ b/man/multiqc_parse_plots.Rd
@@ -8,6 +8,8 @@ multiqc_parse_plots(j, plot_names = NULL)
 }
 \arguments{
 \item{j}{Path to \code{multiqc_data.json} file.}
+
+\item{plot_names}{Names of plots to parse.}
 }
 \value{
 Nested tibble with plot name and result as list column (use \code{tidyr::unnest} to access).


### PR DESCRIPTION
Clarifying the duplicated file types error (issue #63) which occurs when the input directory contains multiple raw files with the same suffix pattern.

```
$ cp dracarys_gds_sync/PRJ230276_L2300562_Fusions.csv dracarys_gds_sync/FOO_Fusions.csv


$ dracarys.R tidy -i dracarys_gds_sync -o ~/tmp/dracarys/tso/L2300562 -p L2300562 -f tsv

✖ Aborting - the input dir dracarys_gds_sync contains duplicated file types. See JSON below:

[{"type":"tso__fusions_csv","type_count":2,"two_example_paths":[{"path":"dracarys_gds_sync/FOO_Fusions.csv"},{"path":"dracarys_gds_sync/PRJ230276_L2300562_Fusions.csv"}]}]

Error:
! Aborting - the input dir dracarys_gds_sync contains duplicated file types. See JSON above!
Backtrace:
    ▆
 1. └─global tidy_parse_args(args)
 2.   ├─base::do.call(umccr_tidy, tidy_args)
 3.   └─dracarys (local) `<fn>`(...)
 4.     └─cli::cli_abort("Aborting - the input dir {.file {in_dir}} contains duplicated file types. See JSON above!") at dracarys/R/tidy.R:85:6
 5.       └─rlang::abort(...)
Execution halted
```


If you have entire directories of raw data mixed together, it will show the paths to two files with the same file type, e.g.:


```
[
    {
        "type": "tso__align_collapse_fusion_caller_metrics",
        "type_count": 5,
        "two_example_paths": [
            {
                "path": "dracarys_gds_sync/FOO.AlignCollapseFusionCaller_metrics.json.gz"
            },
            {
                "path": "dracarys_gds_sync/PRJ230276_L2300562.AlignCollapseFusionCaller_metrics.json.gz"
            }
        ]
    },
    {
        "type": "tso__fragment_length_hist",
        "type_count": 24,
        "two_example_paths": [
            {
                "path": "dracarys_gds_sync/FOO.fragment_length_hist.json.gz"
            },
            {
                "path": "dracarys_gds_sync/PRJ230276_L2300562.fragment_length_hist.json.gz"
            }
        ]
    },
```

JSON is minified so that it doesn't take over the entire log, pretty-printed above for clarity.

Resolves #63.