### PR TITLE
Portal metadata summary

### DIFF
--- a/R/portal_meta.R
+++ b/R/portal_meta.R
@@ -318,8 +318,8 @@ meta_umccrise <- function(pmeta, status = "Succeeded") {
       umccrise_outdir_name2 = purrr::map_chr(.data$input, "output_directory_name", .default = NA),
       umccrise_genomes_tar2 = purrr::map_chr(.data$input, list("genomes_tar", "location"), .default = NA),
       sbjid2 = purrr::map_chr(.data$input, "subject_identifier", .default = NA),
-      dragen_normal_libid2 = sub("(L.*)__(L.*)", "\\1", .data$umccrise_outdir_name2),
-      dragen_tumor_libid2 = sub("(L.*)__(L.*)", "\\2", .data$umccrise_outdir_name2),
+      dragen_tumor_libid2 = sub("(L.*)__(L.*)", "\\1", .data$umccrise_outdir_name2),
+      dragen_normal_libid2 = sub("(L.*)__(L.*)", "\\2", .data$umccrise_outdir_name2),
       # old runs
       dragen_normal_sampleid1 = purrr::map_chr(.data$input, extract_fqlist_el, "rgsm"),
       dragen_normal_lane1 = purrr::map_chr(.data$input, extract_fqlist_el, "lane"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,12 +10,12 @@ date_log <- function() {
 #'
 #' Session information kables for vignettes.
 #'
-#' @param pkgs Vector of R packages to display in the vignette.
+#' @param pkgs Vector of R packages to display in the vignette. By default returns all.
 #'
 #' @return A list with two kables containing information about the platform and
 #' the specified packages (`pkgs`).
 #' @export
-session_info_kable <- function(pkgs) {
+session_info_kable <- function(pkgs = NULL) {
   si <- sessioninfo::session_info(include_base = TRUE)
   assertthat::assert_that(all(c("platform", "packages") %in% names(si)))
   si_pl <- unclass(si[["platform"]]) |>
@@ -26,9 +26,11 @@ session_info_kable <- function(pkgs) {
     dplyr::select(
       "package",
       version = "ondiskversion", datestamp = "date", "source"
-    ) |>
-    dplyr::filter(.data$package %in% pkgs)
-
+    )
+  if (!is.null(pkgs)) {
+    si_pkg <- si_pkg |>
+      dplyr::filter(.data$package %in% pkgs)
+  }
   list(
     si_pl = knitr::kable(si_pl, caption = "Platform information."),
     si_pkg = knitr::kable(si_pkg, caption = "Main packages used.")

--- a/inst/rmd/portal/portal_summary.Rmd
+++ b/inst/rmd/portal/portal_summary.Rmd
@@ -1,0 +1,298 @@
+---
+author: "University of Melbourne Centre for Cancer Research"
+date: "`r lubridate::date()`"
+output:
+  html_document:
+    toc: true
+params:
+  title: "UMCCR Portal Workflow Summary Report"
+description: "UMCCR Portal Workflow Summary Report"
+title: "`r params$title`"
+---
+
+```{r knitr_opts, include=F}
+knitr::opts_chunk$set(
+  collapse = TRUE, echo = FALSE,
+  warning = FALSE, message = FALSE
+)
+```
+
+```{r load_pkgs}
+{
+  require(dplyr)
+  require(tidyr)
+  require(purrr)
+  require(tibble)
+  require(readr)
+  require(dracarys)
+  require(glue, include.only = "glue")
+  require(here, include.only = "here")
+  require(knitr, include.only = "kable")
+  require(DT)
+  require(fs)
+}
+```
+
+```{r funcs}
+dt_view <- function(x) {
+  x |>
+    DT::datatable(
+      filter = list(position = "top", clear = FALSE, plain = TRUE),
+      class = "cell-border display compact",
+      rownames = FALSE,
+      extensions = c("Scroller", "Buttons", "KeyTable"),
+      options = list(
+        scroller = TRUE, scrollY = 400, scrollX = TRUE,
+        autoWidth = FALSE, keys = TRUE,
+        buttons = c("csv"), dom = "Blfrtip"
+      )
+    )
+}
+blank_lines <- function(n = 10) {
+  cat(rep("&nbsp;  ", n), sep = "\n")
+}
+```
+
+```{r vars}
+options(scipen = 999) # disable scientific notation
+# options(width = 150)
+start_date <- "2023-05-31"
+token <- dracarys::ica_token_validate(Sys.getenv("ICA_ACCESS_TOKEN_PRO"))
+wf_order <- c(
+  "bcl_convert",
+  "tso_ctdna_tumor_only",
+  "wgs_alignment_qc",
+  "wts_tumor_only",
+  "wgs_tumor_normal",
+  "umccrise",
+  "rnasum"
+)
+pmeta <- here("nogit/data_portal/2023-06-05_workflows.csv") |>
+  dracarys:::portal_meta_read() |>
+  dplyr::filter(start >= start_date) |>
+  dplyr::mutate(type_name = factor(.data$type_name, levels = wf_order))
+lims <- file.path("~/Downloads/Google LIMS - Sheet1.tsv") |>
+  readr::read_tsv(col_types = readr::cols(.default = "c", Timestamp = "T"))
+```
+
+## Summary for Workflows Run after `r start_date`
+
+- Workflow Types
+
+```{r data_setup}
+pmeta |>
+  dplyr::count(type_name) |>
+  knitr::kable()
+```
+
+### Runtime Visualisation {.tabset .tabset-pills}
+
+#### vistime
+
+Using [vistime](https://github.com/shosaco/vistime):
+
+```{r vistime, fig.height=15, fig.width=10}
+p1 <- pmeta |>
+  dplyr::select(
+    start, end, wfr_name, type_name, wfr_id, portal_run_id
+  ) |>
+  dplyr::rowwise() |>
+  dplyr::mutate(
+    wfr_name2 = as.character(glue("umccr__automated__{.data$type_name}__")),
+    wfr_name3 = sub(paste0(.data$wfr_name2, "(.*)__2023.*"), "\\1", .data$wfr_name),
+    # fontcolor = "grey95"
+  ) |>
+  dplyr::ungroup() |>
+  dplyr::group_by(wfr_name3, type_name) |>
+  dplyr::mutate(
+    n_type = n(),
+    is_dup_type = n_type > 1
+  ) |>
+  dplyr::ungroup() |>
+  # take care of rnasum re-runs
+  dplyr::mutate(wfr_name3 = if_else(is_dup_type, paste0(wfr_name3, "_", portal_run_id), wfr_name3))
+vistime1 <- p1 |>
+  vistime::vistime(
+    col.event = "wfr_name3",
+    col.group = "type_name",
+    show_labels = TRUE,
+    optimize_y = FALSE,
+    linewidth = 15
+  )
+# Decrease font size
+## step 1: transform into a list
+pp <- plotly::plotly_build(vistime1)
+
+# step 2: loop over pp$x$data, and change the font size of all text elements
+font_size <- 10
+for (i in seq_along(pp$x$data)) {
+  if (pp$x$data[[i]]$mode == "text") pp$x$data[[i]]$textfont$size <- font_size
+}
+
+pp
+```
+
+```{r, results='asis'}
+blank_lines(5)
+```
+
+#### timevis
+
+Using [timevis](https://github.com/daattali/timevis):
+
+```{r timevis, fig.height=10, fig.width=10}
+p2 <- p1 |>
+  dplyr::mutate(group = as.integer(type_name)) |>
+  dplyr::select(content = wfr_name3, group, start, end)
+gp2 <- p1 |>
+  dplyr::select(content = type_name) |>
+  dplyr::distinct() |>
+  dplyr::mutate(id = as.integer(content))
+timevis::timevis(p2, groups = gp2)
+```
+
+```{r, results='asis'}
+# need to add blank lines else
+# all hell breaks loose.
+blank_lines(65)
+```
+
+## 1. `bcl_convert`
+
+```{r}
+pmeta |>
+  dracarys::meta_bcl_convert() |>
+  dplyr::select(
+    runfolder_name, LibraryID, SampleID, batch_name, start, end
+  ) |>
+  # one lib (L2300320) has been sequenced previously
+  dplyr::left_join(lims |> filter(!(LibraryID == "L2300320" & Run == "145")), by = c("LibraryID", "SampleID")) |>
+  dplyr::select(
+    runfolder_name, SubjectID, LibraryID, SampleID, ExternalSubjectID,
+    batch_name, start, end,
+    ProjectOwner, ProjectName, Type, Assay, Phenotype, Source, Quality, Workflow
+  ) |>
+  dt_view()
+```
+
+## 2. `tso_ctdna_tumor_only`
+
+- The two Failed runs are handled separately
+
+```{r}
+failed_cttso <- pmeta |>
+  dplyr::filter(type_name == "tso_ctdna_tumor_only", end_status == "Failed") |>
+  dplyr::rowwise() |>
+  dplyr::mutate(
+    input = list(jsonlite::fromJSON(.data$input))
+  ) |>
+  dplyr::ungroup() |>
+  dplyr::mutate(
+    sample_id = purrr::map_chr(.data$input, list("tso500_samples", "sample_id")),
+    SampleID = purrr::map_chr(.data$input, list("tso500_samples", "sample_name")),
+    LibraryID = sub(".*_(L.*)", "\\1", .data$sample_id),
+    SubjectID = sub("umccr__automated__tso_ctdna_tumor_only__(SBJ.*)__L.*", "\\1", .data$wfr_name)
+  ) |>
+  dplyr::select(
+    SubjectID, LibraryID, SampleID, batch_run_id, wfr_id, start, end, portal_run_id, sequence_run_id, version, id, wfr_name
+  )
+pmeta |>
+  dracarys::meta_tso_ctdna_tumor_only() |>
+  dplyr::bind_rows(failed_cttso) |>
+  dplyr::left_join(lims, by = c("LibraryID", "SampleID", "SubjectID")) |>
+  dplyr::select(
+    SubjectID, LibraryID, SampleID, ExternalSubjectID,
+    batch_run_id, wfr_id, start, end, gds_outdir,
+    ProjectOwner, ProjectName, Type, Assay, Phenotype, Source, Quality, Workflow
+  ) |>
+  dt_view()
+```
+
+## 3. `wgs_alignment_qc`
+
+```{r}
+pmeta |>
+  dracarys::meta_wgs_alignment_qc() |>
+  # one lib (L2300320) has been sequenced previously
+  dplyr::left_join(lims |> filter(!(LibraryID == "L2300320" & Run == "145")), by = c("LibraryID", "SampleID", "SubjectID")) |>
+  dplyr::select(
+    SubjectID, LibraryID, SampleID, ExternalSubjectID,
+    Lane, gds_outdir_dragen, batch_run_id, wfr_id, start, end,
+    ProjectOwner, ProjectName, Type, Assay, Phenotype, Source, Quality, Workflow
+  ) |>
+  dt_view()
+```
+
+## 4. `wts_tumor_only`
+
+```{r}
+pmeta |>
+  dracarys::meta_wts_tumor_only() |>
+  dplyr::left_join(lims, by = c("LibraryID", "SampleID", "SubjectID")) |>
+  dplyr::select(
+    SubjectID, LibraryID, SampleID, ExternalSubjectID,
+    gds_outdir_dragen, batch_run_id, wfr_id, start, end,
+    ProjectOwner, ProjectName, Type, Assay, Phenotype, Source, Quality, Workflow
+  ) |>
+  dt_view()
+```
+
+## 5. `wgs_tumor_normal`
+
+```{r}
+pmeta |>
+  dracarys::meta_wgs_tumor_normal() |>
+  tidyr::unite("SampleID__LibraryID___normal", SampleID_normal, LibraryID_normal, sep = "__") |>
+  tidyr::unite("SampleID__LibraryID___tumor", SampleID_tumor, LibraryID_tumor, sep = "__") |>
+  tidyr::pivot_longer(c("SampleID__LibraryID___normal", "SampleID__LibraryID___tumor"), names_to = c(NA, "Phenotype"), names_sep = "___", values_to = "SampleID__LibraryID") |>
+  tidyr::separate_wider_delim("SampleID__LibraryID", delim = "__", names = c("SampleID", "LibraryID")) |>
+  # include Phenotype to double-check join
+  dplyr::left_join(lims, by = c("LibraryID", "SampleID", "SubjectID", "Phenotype")) |>
+  dplyr::select(
+    SubjectID, LibraryID, SampleID, ExternalSubjectID,
+    gds_outdir_dragen_somatic, gds_outdir_dragen_germline, wfr_id, start, end,
+    ProjectOwner, ProjectName, Type, Assay, Phenotype, Source, Quality, Workflow
+  ) |>
+  dt_view()
+```
+
+## 6. `umccrise`
+
+```{r}
+pmeta |>
+  dracarys::meta_umccrise() |>
+  tidyr::unite("SampleID__LibraryID___normal", SampleID_normal, LibraryID_normal, sep = "__") |>
+  tidyr::unite("SampleID__LibraryID___tumor", SampleID_tumor, LibraryID_tumor, sep = "__") |>
+  tidyr::pivot_longer(c("SampleID__LibraryID___normal", "SampleID__LibraryID___tumor"), names_to = c(NA, "Phenotype"), names_sep = "___", values_to = "SampleID__LibraryID") |>
+  tidyr::separate_wider_delim("SampleID__LibraryID", delim = "__", names = c("SampleID", "LibraryID")) |>
+  # include Phenotype to double-check join
+  dplyr::left_join(lims, by = c("LibraryID", "SampleID", "SubjectID", "Phenotype")) |>
+  dplyr::select(
+    SubjectID, LibraryID, SampleID, ExternalSubjectID,
+    gds_outdir_umccrise, wfr_id, start, end,
+    ProjectOwner, ProjectName, Type, Assay, Phenotype, Source, Quality, Workflow
+  ) |>
+  dt_view()
+```
+
+## 7. `rnasum`
+
+```{r}
+pmeta |>
+  dracarys::meta_rnasum() |>
+  dplyr::left_join(lims, by = c("LibraryID", "SampleID", "SubjectID")) |>
+  dplyr::select(
+    SubjectID, LibraryID, SampleID, ExternalSubjectID,
+    rnasum_dataset, gds_outdir_rnasum, wfr_id, start, end,
+    ProjectOwner, ProjectName, Type, Assay, Phenotype, Source, Quality, Workflow
+  ) |>
+  dt_view()
+```
+
+## Session Info
+
+```{r}
+si <- dracarys::session_info_kable()
+si$si_pkg
+si$si_pl
+```

--- a/man/session_info_kable.Rd
+++ b/man/session_info_kable.Rd
@@ -4,10 +4,10 @@
 \alias{session_info_kable}
 \title{Session Information Kable}
 \usage{
-session_info_kable(pkgs)
+session_info_kable(pkgs = NULL)
 }
 \arguments{
-\item{pkgs}{Vector of R packages to display in the vignette.}
+\item{pkgs}{Vector of R packages to display in the vignette. By default returns all.}
 }
 \value{
 A list with two kables containing information about the platform and

--- a/tests/testthat/test-roxytest-testexamples-portal_meta.R
+++ b/tests/testthat/test-roxytest-testexamples-portal_meta.R
@@ -11,7 +11,7 @@ test_that("Function meta_bcl_convert() @ L14", {
 })
 
 
-test_that("Function meta_wts_tumor_only() @ L77", {
+test_that("Function meta_wts_tumor_only() @ L78", {
   
   pmeta <- system.file("extdata/portal_meta_top4.csv", package = "dracarys")
   (m <- meta_wts_tumor_only(pmeta))
@@ -20,7 +20,7 @@ test_that("Function meta_wts_tumor_only() @ L77", {
 })
 
 
-test_that("Function meta_rnasum() @ L127", {
+test_that("Function meta_rnasum() @ L128", {
   
   pmeta <- system.file("extdata/portal_meta_top4.csv", package = "dracarys")
   (m <- meta_rnasum(pmeta))
@@ -29,7 +29,7 @@ test_that("Function meta_rnasum() @ L127", {
 })
 
 
-test_that("Function meta_wgs_alignment_qc() @ L179", {
+test_that("Function meta_wgs_alignment_qc() @ L180", {
   
   pmeta <- system.file("extdata/portal_meta_top4.csv", package = "dracarys")
   (m <- meta_wgs_alignment_qc(pmeta))
@@ -37,7 +37,7 @@ test_that("Function meta_wgs_alignment_qc() @ L179", {
 })
 
 
-test_that("Function meta_wgs_tumor_normal() @ L224", {
+test_that("Function meta_wgs_tumor_normal() @ L225", {
   
   pmeta <- system.file("extdata/portal_meta_top4.csv", package = "dracarys")
   (m <- meta_wgs_tumor_normal(pmeta))
@@ -45,7 +45,7 @@ test_that("Function meta_wgs_tumor_normal() @ L224", {
 })
 
 
-test_that("Function meta_umccrise() @ L291", {
+test_that("Function meta_umccrise() @ L292", {
   
   pmeta <- system.file("extdata/portal_meta_top4.csv", package = "dracarys")
   (m <- meta_umccrise(pmeta))
@@ -53,7 +53,7 @@ test_that("Function meta_umccrise() @ L291", {
 })
 
 
-test_that("Function meta_tso_ctdna_tumor_only() @ L383", {
+test_that("Function meta_tso_ctdna_tumor_only() @ L384", {
   
   pmeta <- system.file("extdata/portal_meta_top4.csv", package = "dracarys")
   (m <- meta_tso_ctdna_tumor_only(pmeta))


### PR DESCRIPTION
Latest workflow runs were a bit noisy so went ahead and set up a metadata summary.
Includes a vis of the workflow runtime (`start` to `end`), along with tidied metadata tables joined with Google LIMS.

![Screenshot 2023-06-05 at 23 37 25](https://github.com/umccr/dracarys/assets/29562861/8631d3df-b0c3-470f-932e-b013346617e6)

