### PR TITLE
Fix: Handle presigned URLs of gzipped JSONs

### DIFF
--- a/R/ica.R
+++ b/R/ica.R
@@ -81,6 +81,8 @@ gds_file_download <- function(gds, out, token = Sys.getenv("ICA_ACCESS_TOKEN")) 
 #'
 #' @param gdsdir Full path to GDS directory.
 #' @param token ICA access token (def: $ICA_ACCESS_TOKEN env var).
+#' @param include Use PresignedUrl to include presigned URLs to all files within
+#' the GDS directory.
 #'
 #' @return Tibble with file basename, file size, file full data path, file dir name.
 #' @export
@@ -96,10 +98,12 @@ gds_files_list <- function(gdsdir, token, include = NULL) {
   path2 <- sub("gds://(.*?)/(.*)", "\\2", gdsdir)
   query_url <- glue("{base_url}/files?volume.name={volname}&path=/{path2}*&pageSize=100")
   if (!is.null(include)) {
-    assertthat::assert_that(include == "PresignedUrl")
-    query_url <- glue("{query_url}&include=PresignedUrl")
+    .url_include_presignedurl <- function(x, incl) {
+      assertthat::assert_that(incl == "PresignedUrl")
+      glue("{x}&include=PresignedUrl")
+    }
+    query_url <- .url_include_presignedurl(query_url, include)
   }
-
   res <- httr::GET(
     query_url,
     httr::add_headers(Authorization = glue("Bearer {token}")),

--- a/man/gds_files_list.Rd
+++ b/man/gds_files_list.Rd
@@ -10,6 +10,9 @@ gds_files_list(gdsdir, token, include = NULL)
 \item{gdsdir}{Full path to GDS directory.}
 
 \item{token}{ICA access token (def: $ICA_ACCESS_TOKEN env var).}
+
+\item{include}{Use PresignedUrl to include presigned URLs to all files within
+the GDS directory.}
 }
 \value{
 Tibble with file basename, file size, file full data path, file dir name.


### PR DESCRIPTION
Fixes #74.

``` r
require(dracarys)
require(dplyr)
```

``` r
url_jsongz1 <- "https://stratus-gds-aps2.[...]/[...]AlignCollapseFusionCaller_metrics.json.gz?[...]"
url_jsongz2 <- "https://stratus-gds-aps2.[...]/[...]TargetRegionCoverage.json.gz?[...]"
url_multiqc_ungz <- "https://stratus-gds-aps2.[...]/[...]ctDNA_alignment_collapse_fusion_caller_multiqc_data/multiqc_data.json?[...]"

dracarys::TsoTargetRegionCoverageFile$new(url_jsongz2)$read()
```

    ## # A tibble: 14 × 3
    ##    ConsensusReadDepth BasePair Percentage
    ##    <chr>              <chr>         <dbl>
    ##  1 TargetRegion       1970825      100   
    ##  2 100X               1957963       99.4 
    ##  3 250X               1949650       98.9 
    ##  4 500X               1936676       98.3 
    ##  5 750X               1923801       97.6 
    ##  6 1000X              1910759       97.0 

``` r
dracarys::TsoAlignCollapseFusionCallerMetricsFile$new(url_jsongz1)$read()
```

    ## # A tibble: 338 × 4
    ##    section              name                                       value percent
    ##    <chr>                <chr>                                      <chr> <chr>  
    ##  1 MappingAligningPerRg Total reads in RG                          1185… 100    
    ##  2 MappingAligningPerRg Number of duplicate marked reads           0     0      
    ##  3 MappingAligningPerRg Number of duplicate marked and mate reads… 0     0      
    ##  4 MappingAligningPerRg Number of unique reads (excl. duplicate m… 1185… 100    
    ##  5 MappingAligningPerRg Reads with mate sequenced                  1185… 100    
    ##  6 MappingAligningPerRg Reads without mate sequenced               0     0      
    ##  7 MappingAligningPerRg QC-failed reads                            0     0      
    ##  8 MappingAligningPerRg Mapped reads                               1179… 99.5   
    ##  9 MappingAligningPerRg Mapped reads R1                            5914… 99.81  
    ## 10 MappingAligningPerRg Mapped reads R2                            5877… 99.2   
    ## # ℹ 328 more rows

``` r
dracarys::MultiqcFile$new(url_multiqc_ungz)$read()
```

    ## # A tibble: 1 × 119
    ##   umccr_id           umccr_workflow date_multiqc        reads_tot_input_dragen
    ##   <chr>              <chr>          <chr>                                <dbl>
    ## 1 PRJ23XXXX_L23XXXXX dragen_ctdna   2023-06-03T01:17:00             1185038900
    ## # ℹ 115 more variables: reads_tot_input_pct_dragen <dbl>,
    ## #   reads_num_dupmarked_dragen <dbl>, reads_num_dupmarked_pct_dragen <dbl>,
    ## #   reads_num_dupmarked_mate_reads_removed_pct_dragen <dbl>,
    ## #   reads_num_unique_pct_dragen <dbl>, reads_w_mate_seq_dragen <dbl>,
    ## #   reads_w_mate_seq_pct_dragen <dbl>, reads_wo_mate_seq_dragen <dbl>,
    ## #   reads_wo_mate_seq_pct_dragen <dbl>, reads_qcfail_dragen <dbl>,
    ## #   reads_qcfail_pct_dragen <dbl>, reads_mapped_dragen <dbl>, …
