### PR TITLE
Add Air formatter support

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,6 +12,7 @@
 ^\.github$
 ^\.pre-commit-config\.yaml$
 ^_pkgdown\.yaml$
+^air\.toml$
 ^conda$
 ^data-raw$
 ^docs$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,13 @@ repos:
 -   repo: https://github.com/lorenzwalthert/precommit
     rev: v0.4.3
     hooks:
-    -   id: style-files
-        args: [--style_pkg=styler, --style_fun=tidyverse_style]
-        exclude:  > 
-          (?x)^(
-          tests/testthat/.*\.R|
-          renv/.*
-          )$
+    #-   id: style-files
+    #    args: [--style_pkg=styler, --style_fun=tidyverse_style]
+    #    exclude:  > 
+    #      (?x)^(
+    #      tests/testthat/.*\.R|
+    #      renv/.*
+    #      )$
     -   id: use-tidy-description
     -   id: readme-rmd-rendered
     -   id: pkgdown

--- a/R/File.R
+++ b/R/File.R
@@ -18,49 +18,52 @@
 #' expect_equal(F2$is_url, TRUE)
 #'
 #' @export
-File <- R6::R6Class("File", public = list(
-  #' @field path Name or full path of the file.
-  #' @field is_url Is the file a presigned URL?
-  path = NULL,
-  is_url = NULL,
+File <- R6::R6Class(
+  "File",
+  public = list(
+    #' @field path Name or full path of the file.
+    #' @field is_url Is the file a presigned URL?
+    path = NULL,
+    is_url = NULL,
 
-  #' @description Create a new File object.
-  #' @param is_url Is the file a presigned URL?
-  #' @param path Name or full path of the file.
-  initialize = function(path = NULL, is_url = NULL) {
-    stopifnot(is.character(path), length(path) == 1)
-    self$is_url <- is_url(path)
-    self$path <- base::ifelse(is_url(path), path, normalizePath(path))
-  },
+    #' @description Create a new File object.
+    #' @param is_url Is the file a presigned URL?
+    #' @param path Name or full path of the file.
+    initialize = function(path = NULL, is_url = NULL) {
+      stopifnot(is.character(path), length(path) == 1)
+      self$is_url <- is_url(path)
+      self$path <- base::ifelse(is_url(path), path, normalizePath(path))
+    },
 
-  #' @description Basename of the file.
-  #' @return Basename of the file as a character vector.
-  bname = function() {
-    x <- self$path
-    if (is_url(x)) {
-      x <- strsplit(self$path, "\\?")[[1]][1]
+    #' @description Basename of the file.
+    #' @return Basename of the file as a character vector.
+    bname = function() {
+      x <- self$path
+      if (is_url(x)) {
+        x <- strsplit(self$path, "\\?")[[1]][1]
+      }
+      basename(x)
+    },
+
+    #' @description Get the type of file.
+    #' @return String describing the specific type of dracarys file (NA if not a dracarys-recognised file).
+    type = function() {
+      nm <- self$bname()
+      match_regex(nm)
+    },
+
+    #' @description Print details about the File.
+    #' @param ... (ignored).
+    print = function(...) {
+      cat("#--- File ---#\n")
+      cat(glue("Path: {self$path}"), "\n")
+      cat(glue("Basename: {self$bname()}"), "\n")
+      cat(glue("Type: {self$type()}"), "\n")
+      cat(glue("isURL: {self$is_url}"), "\n")
+      invisible(self)
     }
-    basename(x)
-  },
-
-  #' @description Get the type of file.
-  #' @return String describing the specific type of dracarys file (NA if not a dracarys-recognised file).
-  type = function() {
-    nm <- self$bname()
-    match_regex(nm)
-  },
-
-  #' @description Print details about the File.
-  #' @param ... (ignored).
-  print = function(...) {
-    cat("#--- File ---#\n")
-    cat(glue("Path: {self$path}"), "\n")
-    cat(glue("Basename: {self$bname()}"), "\n")
-    cat(glue("Type: {self$type()}"), "\n")
-    cat(glue("isURL: {self$is_url}"), "\n")
-    invisible(self)
-  }
-))
+  )
+)
 
 #' Read File object
 #'

--- a/R/Wf.R
+++ b/R/Wf.R
@@ -108,6 +108,7 @@ Wf <- R6::R6Class(
     #' @description Print details about the Workflow.
     #' @param ... (ignored).
     print = function(...) {
+      # fmt: skip
       res <- tibble::tribble(
         ~var, ~value,
         "path", private$.path,
@@ -133,16 +134,25 @@ Wf <- R6::R6Class(
     #' @param path Path with raw results.
     #' @param max_files Max number of files to list.
     #' @param ... Passed on to `s3_list_files_filter_relevant`.
-    list_files_filter_relevant = function(path = private$.path, max_files = 1000, ...) {
+    list_files_filter_relevant = function(
+      path = private$.path,
+      max_files = 1000,
+      ...
+    ) {
       regexes <- private$.regexes
       assertthat::assert_that(!is.null(regexes))
       if (private$.filesystem == "s3") {
         d <- s3_list_files_filter_relevant(
-          s3dir = path, regexes = regexes, max_objects = max_files, ...
+          s3dir = path,
+          regexes = regexes,
+          max_objects = max_files,
+          ...
         )
       } else {
         d <- local_list_files_filter_relevant(
-          localdir = path, regexes = regexes, max_files = max_files
+          localdir = path,
+          regexes = regexes,
+          max_files = max_files
         )
       }
       d
@@ -162,20 +172,31 @@ Wf <- R6::R6Class(
     #' @param max_files Max number of files to list.
     #' @param dryrun If TRUE, just list the files that will be downloaded (don't
     #' download them).
-    download_files = function(path = private$.path, outdir, max_files = 1000, dryrun = FALSE) {
+    download_files = function(
+      path = private$.path,
+      outdir,
+      max_files = 1000,
+      dryrun = FALSE
+    ) {
       regexes <- private$.regexes
       assertthat::assert_that(!is.null(regexes))
       if (private$.filesystem == "s3") {
         d <- dr_s3_download(
-          s3dir = path, outdir = outdir, regexes = regexes,
-          max_objects = max_files, dryrun = dryrun
+          s3dir = path,
+          outdir = outdir,
+          regexes = regexes,
+          max_objects = max_files,
+          dryrun = dryrun
         )
         if (!dryrun) {
           private$.filesystem <- "local"
           private$.path <- outdir
         }
       } else {
-        d <- self$list_files_filter_relevant(regexes = regexes, max_files = max_files)
+        d <- self$list_files_filter_relevant(
+          regexes = regexes,
+          max_files = max_files
+        )
       }
       return(d)
     },
@@ -192,7 +213,13 @@ Wf <- R6::R6Class(
     #' @param prefix Prefix of output files.
     #' @param format Format of output files.
     #' @param drid dracarys ID to use for the dataset (e.g. `wfrid.123`, `prid.456`).
-    write = function(x, outdir = NULL, prefix = NULL, format = "tsv", drid = NULL) {
+    write = function(
+      x,
+      outdir = NULL,
+      prefix = NULL,
+      format = "tsv",
+      drid = NULL
+    ) {
       assertthat::assert_that(!is.null(prefix))
       assertthat::assert_that(all(c("name", "data") %in% colnames(x)))
       if (!is.null(outdir)) {
@@ -208,7 +235,12 @@ Wf <- R6::R6Class(
           ),
           out = ifelse(
             !grepl("DOWNLOAD_ONLY", .data$name),
-            list(write_dracarys(obj = .data$data, prefix = .data$p, out_format = format, drid = drid)),
+            list(write_dracarys(
+              obj = .data$data,
+              prefix = .data$p,
+              out_format = format,
+              drid = drid
+            )),
             list(.data$data)
           )
         ) |>

--- a/R/bcftools_stats.R
+++ b/R/bcftools_stats.R
@@ -25,10 +25,21 @@ BcftoolsStatsFile <- R6::R6Class(
       ln <- readr::read_lines(x)
       d <- ln[grepl("QUAL", ln)]
       # line1 ignore, line2 is colnames, just clean those up
-      cnames <- c("QUAL_dummy", "id", "qual", "snps", "transi", "transv", "indels")
+      cnames <- c(
+        "QUAL_dummy",
+        "id",
+        "qual",
+        "snps",
+        "transi",
+        "transv",
+        "indels"
+      )
       d[3:length(d)] |>
         I() |>
-        readr::read_tsv(col_names = cnames, col_types = readr::cols(.default = "d", "QUAL_dummy" = "c")) |>
+        readr::read_tsv(
+          col_names = cnames,
+          col_types = readr::cols(.default = "d", "QUAL_dummy" = "c")
+        ) |>
         dplyr::select(-"QUAL_dummy")
     },
     #' @description
@@ -40,11 +51,22 @@ BcftoolsStatsFile <- R6::R6Class(
     #' @param out_dir Output directory.
     #' @param out_format Format of output file(s).
     #' @param drid dracarys ID to use for the dataset (e.g. `wfrid.123`, `prid.456`).
-    write = function(d, out_dir = NULL, prefix, out_format = "tsv", drid = NULL) {
+    write = function(
+      d,
+      out_dir = NULL,
+      prefix,
+      out_format = "tsv",
+      drid = NULL
+    ) {
       if (!is.null(out_dir)) {
         prefix <- file.path(out_dir, prefix)
       }
-      write_dracarys(obj = d, prefix = prefix, out_format = out_format, drid = drid)
+      write_dracarys(
+        obj = d,
+        prefix = prefix,
+        out_format = out_format,
+        drid = drid
+      )
     }
   )
 )

--- a/R/bclconvert.R
+++ b/R/bclconvert.R
@@ -72,12 +72,23 @@ BclconvertReports <- R6::R6Class(
     read_adaptercyclemetrics = function(x) {
       cnames <- list(
         old = c(
-          "Lane", "Sample_ID", "index", "index2", "ReadNumber", "Cycle",
-          "NumClustersWithAdapterAtCycle", "% At Cycle"
+          "Lane",
+          "Sample_ID",
+          "index",
+          "index2",
+          "ReadNumber",
+          "Cycle",
+          "NumClustersWithAdapterAtCycle",
+          "% At Cycle"
         ),
         new = c(
-          "lane", "sampleid", "indexes", "read", "cycle",
-          "cluster_n", "cluster_pct"
+          "lane",
+          "sampleid",
+          "indexes",
+          "read",
+          "cycle",
+          "cluster_n",
+          "cluster_pct"
         )
       )
       ctypes <- list(
@@ -110,12 +121,23 @@ BclconvertReports <- R6::R6Class(
     read_adaptermetrics = function(x) {
       cnames <- list(
         old = c(
-          "Lane", "Sample_ID", "index", "index2", "ReadNumber",
-          "AdapterBases", "SampleBases", "% Adapter Bases"
+          "Lane",
+          "Sample_ID",
+          "index",
+          "index2",
+          "ReadNumber",
+          "AdapterBases",
+          "SampleBases",
+          "% Adapter Bases"
         ),
         new = c(
-          "lane", "sampleid", "indexes", "readnum", "adapter_bases",
-          "sample_bases", "adapter_bases_pct"
+          "lane",
+          "sampleid",
+          "indexes",
+          "readnum",
+          "adapter_bases",
+          "sample_bases",
+          "adapter_bases_pct"
         )
       )
       ctypes <- list(
@@ -128,9 +150,13 @@ BclconvertReports <- R6::R6Class(
       d <- readr::read_csv(x, col_types = ctypes$old)
       assertthat::assert_that(all(colnames(d) == cnames$old))
       d |>
-        dplyr::mutate(indexes = ifelse(
-          is.na(.data$index), NA_character_, paste0(.data$index, "-", .data$index2)
-        )) |>
+        dplyr::mutate(
+          indexes = ifelse(
+            is.na(.data$index),
+            NA_character_,
+            paste0(.data$index, "-", .data$index2)
+          )
+        ) |>
         dplyr::select(-c("index", "index2")) |>
         dplyr::relocate("indexes", .after = "Sample_ID") |>
         rlang::set_names(cnames$new)
@@ -154,16 +180,30 @@ BclconvertReports <- R6::R6Class(
     read_demultiplexstats = function(x) {
       cnames <- list(
         old = c(
-          "Lane", "SampleID", "Index", "# Reads", "# Perfect Index Reads",
-          "# One Mismatch Index Reads", "# Two Mismatch Index Reads",
-          "% Reads", "% Perfect Index Reads", "% One Mismatch Index Reads",
+          "Lane",
+          "SampleID",
+          "Index",
+          "# Reads",
+          "# Perfect Index Reads",
+          "# One Mismatch Index Reads",
+          "# Two Mismatch Index Reads",
+          "% Reads",
+          "% Perfect Index Reads",
+          "% One Mismatch Index Reads",
           "% Two Mismatch Index Reads"
         ),
         new = c(
-          "lane", "sampleid", "indexes", "reads_n", "perfect_idxreads_n",
-          "one_mismatch_idxreads_n", "two_mismatch_idxreads_n",
-          "reads_pct", "perfect_idxreads_pct",
-          "one_mismatch_idxreads_pct", "two_mismatch_idxreads_pct"
+          "lane",
+          "sampleid",
+          "indexes",
+          "reads_n",
+          "perfect_idxreads_n",
+          "one_mismatch_idxreads_n",
+          "two_mismatch_idxreads_n",
+          "reads_pct",
+          "perfect_idxreads_pct",
+          "one_mismatch_idxreads_pct",
+          "two_mismatch_idxreads_pct"
         )
       )
       ctypes <- list(
@@ -223,12 +263,27 @@ BclconvertReports <- R6::R6Class(
     read_qualitymetrics = function(x) {
       cnames <- list(
         old = c(
-          "Lane", "SampleID", "index", "index2", "ReadNumber", "Yield",
-          "YieldQ30", "QualityScoreSum", "Mean Quality Score (PF)", "% Q30"
+          "Lane",
+          "SampleID",
+          "index",
+          "index2",
+          "ReadNumber",
+          "Yield",
+          "YieldQ30",
+          "QualityScoreSum",
+          "Mean Quality Score (PF)",
+          "% Q30"
         ),
         new = c(
-          "lane", "sampleid", "indexes", "readnum", "yield",
-          "yieldq30", "qscore_sum", "qscore_mean_pf", "q30_pct"
+          "lane",
+          "sampleid",
+          "indexes",
+          "readnum",
+          "yield",
+          "yieldq30",
+          "qscore_sum",
+          "qscore_mean_pf",
+          "q30_pct"
         )
       )
       ctypes <- list(
@@ -247,7 +302,6 @@ BclconvertReports <- R6::R6Class(
         rlang::set_names(cnames$new)
     },
 
-
     #' @description Read Quality_Tile_Metrics.csv file.
     #'
     #' - lane: lane number.
@@ -265,12 +319,29 @@ BclconvertReports <- R6::R6Class(
     read_qualitytilemetrics = function(x) {
       cnames <- list(
         old = c(
-          "Lane", "SampleID", "index", "index2", "ReadNumber", "Tile", "Yield",
-          "YieldQ30", "QualityScoreSum", "Mean Quality Score (PF)", "% Q30"
+          "Lane",
+          "SampleID",
+          "index",
+          "index2",
+          "ReadNumber",
+          "Tile",
+          "Yield",
+          "YieldQ30",
+          "QualityScoreSum",
+          "Mean Quality Score (PF)",
+          "% Q30"
         ),
         new = c(
-          "lane", "sampleid", "indexes", "readnum", "tile", "yield",
-          "yieldq30", "qscore_sum", "qscore_mean_pf", "q30_pct"
+          "lane",
+          "sampleid",
+          "indexes",
+          "readnum",
+          "tile",
+          "yield",
+          "yieldq30",
+          "qscore_sum",
+          "qscore_mean_pf",
+          "q30_pct"
         )
       )
       ctypes <- list(
@@ -302,12 +373,21 @@ BclconvertReports <- R6::R6Class(
     read_indexhoppingcounts = function(x) {
       cnames <- list(
         old = c(
-          "Lane", "SampleID", "index", "index2", "# Reads",
-          "% of Hopped Reads", "% of All Reads"
+          "Lane",
+          "SampleID",
+          "index",
+          "index2",
+          "# Reads",
+          "% of Hopped Reads",
+          "% of All Reads"
         ),
         new = c(
-          "lane", "sampleid", "indexes",
-          "reads_n", "reads_hopped_pct", "reads_pct"
+          "lane",
+          "sampleid",
+          "indexes",
+          "reads_n",
+          "reads_hopped_pct",
+          "reads_pct"
         )
       )
       ctypes <- list(
@@ -336,7 +416,14 @@ BclconvertReports <- R6::R6Class(
     #'   Path to Top_Unknown_Barcodes.csv file.
     read_topunknownbarcodes = function(x) {
       cnames <- list(
-        old = c("Lane", "index", "index2", "# Reads", "% of Unknown Barcodes", "% of All Reads"),
+        old = c(
+          "Lane",
+          "index",
+          "index2",
+          "# Reads",
+          "% of Unknown Barcodes",
+          "% of All Reads"
+        ),
         new = c("lane", "indexes", "reads_n", "unknownbcodes_pct", "reads_pct")
       )
       ctypes <- list(
@@ -380,7 +467,11 @@ BclconvertReports <- R6::R6Class(
       d <- readr::read_csv(x, col_types = ctypes$old)
       assertthat::assert_that(all(colnames(d) == cnames$old))
       d |>
-        tidyr::pivot_longer(c("Read1File", "Read2File"), names_to = "readnum", values_to = "filepath") |>
+        tidyr::pivot_longer(
+          c("Read1File", "Read2File"),
+          names_to = "readnum",
+          values_to = "filepath"
+        ) |>
         dplyr::mutate(readnum = sub("Read(.)File", "\\1", .data$readnum)) |>
         rlang::set_names(cnames$new)
     },
@@ -394,14 +485,38 @@ BclconvertReports <- R6::R6Class(
       # now return all as list elements
       p <- self$path
       list(
-        adapter_cycle_metrics = self$read_adaptercyclemetrics(file.path(p, "Adapter_Cycle_Metrics.csv")),
-        adapter_metrics = self$read_adaptermetrics(file.path(p, "Adapter_Metrics.csv")),
-        demultiplex_stats = self$read_demultiplexstats(file.path(p, "Demultiplex_Stats.csv")),
-        demultiplex_tile_stats = self$read_demultiplextilestats(file.path(p, "Demultiplex_Tile_Stats.csv")),
-        quality_metrics = self$read_qualitymetrics(file.path(p, "Quality_Metrics.csv")),
-        quality_tile_metrics = self$read_qualitytilemetrics(file.path(p, "Quality_Tile_Metrics.csv")),
-        index_hopping_counts = self$read_indexhoppingcounts(file.path(p, "Index_Hopping_Counts.csv")),
-        top_unknown_barcodes = self$read_topunknownbarcodes(file.path(p, "Top_Unknown_Barcodes.csv")),
+        adapter_cycle_metrics = self$read_adaptercyclemetrics(file.path(
+          p,
+          "Adapter_Cycle_Metrics.csv"
+        )),
+        adapter_metrics = self$read_adaptermetrics(file.path(
+          p,
+          "Adapter_Metrics.csv"
+        )),
+        demultiplex_stats = self$read_demultiplexstats(file.path(
+          p,
+          "Demultiplex_Stats.csv"
+        )),
+        demultiplex_tile_stats = self$read_demultiplextilestats(file.path(
+          p,
+          "Demultiplex_Tile_Stats.csv"
+        )),
+        quality_metrics = self$read_qualitymetrics(file.path(
+          p,
+          "Quality_Metrics.csv"
+        )),
+        quality_tile_metrics = self$read_qualitytilemetrics(file.path(
+          p,
+          "Quality_Tile_Metrics.csv"
+        )),
+        index_hopping_counts = self$read_indexhoppingcounts(file.path(
+          p,
+          "Index_Hopping_Counts.csv"
+        )),
+        top_unknown_barcodes = self$read_topunknownbarcodes(file.path(
+          p,
+          "Top_Unknown_Barcodes.csv"
+        )),
         fastq_list = self$read_fastqlist(file.path(p, "fastq_list.csv"))
       )
     },
@@ -414,7 +529,13 @@ BclconvertReports <- R6::R6Class(
     #' @param out_dir Output directory.
     #' @param out_format Format of output file(s).
     #' @param drid dracarys ID to use for the dataset (e.g. `wfrid.123`, `prid.456`).
-    write = function(d, out_dir = NULL, prefix, out_format = "tsv", drid = NULL) {
+    write = function(
+      d,
+      out_dir = NULL,
+      prefix,
+      out_format = "tsv",
+      drid = NULL
+    ) {
       if (!is.null(out_dir)) {
         prefix <- file.path(out_dir, prefix)
       }
@@ -424,7 +545,12 @@ BclconvertReports <- R6::R6Class(
         dplyr::mutate(
           section_low = tolower(.data$section),
           p = glue("{prefix}_{.data$section_low}"),
-          out = list(write_dracarys(obj = .data$value, prefix = .data$p, out_format = out_format, drid = drid))
+          out = list(write_dracarys(
+            obj = .data$value,
+            prefix = .data$p,
+            out_format = out_format,
+            drid = drid
+          ))
         ) |>
         dplyr::ungroup() |>
         dplyr::select("section", "value") |>
@@ -499,12 +625,25 @@ BclconvertReports375 <- R6::R6Class(
     read_adaptermetrics = function(x) {
       cnames <- list(
         old = c(
-          "Lane", "Sample_ID", "index", "index2", "R1_AdapterBases",
-          "R1_SampleBases", "R2_AdapterBases", "R2_SampleBases", "# Reads"
+          "Lane",
+          "Sample_ID",
+          "index",
+          "index2",
+          "R1_AdapterBases",
+          "R1_SampleBases",
+          "R2_AdapterBases",
+          "R2_SampleBases",
+          "# Reads"
         ),
         new = c(
-          "lane", "sampleid", "indexes", "adapter_bases_r1", "sample_bases_r1",
-          "adapter_bases_r2", "sample_bases_r2", "reads_n"
+          "lane",
+          "sampleid",
+          "indexes",
+          "adapter_bases_r1",
+          "sample_bases_r1",
+          "adapter_bases_r2",
+          "sample_bases_r2",
+          "reads_n"
         )
       )
       ctypes <- list(
@@ -517,9 +656,13 @@ BclconvertReports375 <- R6::R6Class(
       d <- readr::read_csv(x, col_types = ctypes$old)
       assertthat::assert_that(all(colnames(d) == cnames$old))
       d |>
-        dplyr::mutate(indexes = ifelse(
-          is.na(.data$index), NA_character_, paste0(.data$index, "-", .data$index2)
-        )) |>
+        dplyr::mutate(
+          indexes = ifelse(
+            is.na(.data$index),
+            NA_character_,
+            paste0(.data$index, "-", .data$index2)
+          )
+        ) |>
         dplyr::select(-c("index", "index2")) |>
         dplyr::relocate("indexes", .after = "Sample_ID") |>
         rlang::set_names(cnames$new)
@@ -532,13 +675,24 @@ BclconvertReports375 <- R6::R6Class(
     read_demultiplexstats = function(x) {
       cnames <- list(
         old = c(
-          "Lane", "SampleID", "Index", "# Reads", "# Perfect Index Reads",
-          "# One Mismatch Index Reads", "# of >= Q30 Bases (PF)",
+          "Lane",
+          "SampleID",
+          "Index",
+          "# Reads",
+          "# Perfect Index Reads",
+          "# One Mismatch Index Reads",
+          "# of >= Q30 Bases (PF)",
           "Mean Quality Score (PF)"
         ),
         new = c(
-          "lane", "sampleid", "indexes", "reads_n", "perfect_idxreads_n",
-          "one_mismatch_idxreads_n", "q30_bases_n", "qscore_mean_pf"
+          "lane",
+          "sampleid",
+          "indexes",
+          "reads_n",
+          "perfect_idxreads_n",
+          "one_mismatch_idxreads_n",
+          "q30_bases_n",
+          "qscore_mean_pf"
         )
       )
       ctypes <- list(
@@ -629,7 +783,11 @@ BclconvertReports375 <- R6::R6Class(
       d <- readr::read_csv(x, col_types = ctypes$old)
       assertthat::assert_that(all(colnames(d) == cnames$old))
       d |>
-        tidyr::pivot_longer(c("Read1File", "Read2File"), names_to = "readnum", values_to = "filepath") |>
+        tidyr::pivot_longer(
+          c("Read1File", "Read2File"),
+          names_to = "readnum",
+          values_to = "filepath"
+        ) |>
         dplyr::mutate(readnum = sub("Read(.)File", "\\1", .data$readnum)) |>
         rlang::set_names(cnames$new)
     },
@@ -643,10 +801,22 @@ BclconvertReports375 <- R6::R6Class(
       # now return all as list elements
       p <- self$path
       list(
-        adapter_metrics = self$read_adaptermetrics(file.path(p, "Adapter_Metrics.csv")),
-        demultiplex_stats = self$read_demultiplexstats(file.path(p, "Demultiplex_Stats.csv")),
-        index_hopping_counts = self$read_indexhoppingcounts(file.path(p, "Index_Hopping_Counts.csv")),
-        top_unknown_barcodes = self$read_topunknownbarcodes(file.path(p, "Top_Unknown_Barcodes.csv")),
+        adapter_metrics = self$read_adaptermetrics(file.path(
+          p,
+          "Adapter_Metrics.csv"
+        )),
+        demultiplex_stats = self$read_demultiplexstats(file.path(
+          p,
+          "Demultiplex_Stats.csv"
+        )),
+        index_hopping_counts = self$read_indexhoppingcounts(file.path(
+          p,
+          "Index_Hopping_Counts.csv"
+        )),
+        top_unknown_barcodes = self$read_topunknownbarcodes(file.path(
+          p,
+          "Top_Unknown_Barcodes.csv"
+        )),
         fastq_list = self$read_fastqlist(file.path(p, "fastq_list.csv"))
       )
     },
@@ -659,7 +829,13 @@ BclconvertReports375 <- R6::R6Class(
     #' @param out_dir Output directory.
     #' @param out_format Format of output file(s).
     #' @param drid dracarys ID to use for the dataset (e.g. `wfrid.123`, `prid.456`).
-    write = function(d, out_dir = NULL, prefix, out_format = "tsv", drid = NULL) {
+    write = function(
+      d,
+      out_dir = NULL,
+      prefix,
+      out_format = "tsv",
+      drid = NULL
+    ) {
       if (!is.null(out_dir)) {
         prefix <- file.path(out_dir, prefix)
       }
@@ -669,7 +845,12 @@ BclconvertReports375 <- R6::R6Class(
         dplyr::mutate(
           section_low = tolower(.data$section),
           p = glue("{prefix}_{.data$section_low}"),
-          out = list(write_dracarys(obj = .data$value, prefix = .data$p, out_format = out_format, drid = drid))
+          out = list(write_dracarys(
+            obj = .data$value,
+            prefix = .data$p,
+            out_format = out_format,
+            drid = drid
+          ))
         ) |>
         dplyr::ungroup() |>
         dplyr::select("section", "value") |>

--- a/R/dragen.R
+++ b/R/dragen.R
@@ -23,7 +23,11 @@ dragen_fraglenhist_plot <- function(d, min_count = 10) {
       legend.justification = c(1, 1),
       panel.grid.minor = ggplot2::element_blank(),
       panel.grid.major = ggplot2::element_blank(),
-      plot.title = ggplot2::element_text(colour = "#2c3e50", size = 14, face = "bold")
+      plot.title = ggplot2::element_text(
+        colour = "#2c3e50",
+        size = 14,
+        face = "bold"
+      )
     )
 }
 
@@ -42,6 +46,7 @@ dragen_fraglenhist_plot <- function(d, min_count = 10) {
 dragen_umi_metrics_read <- function(x) {
   d0 <- readr::read_lines(x)
   assertthat::assert_that(grepl("UMI STATISTICS", d0[1]))
+  # fmt: skip
   abbrev_nm <- tibble::tribble(
     ~raw, ~clean, ~target,
     "number of reads", "reads_tot", TRUE,
@@ -83,7 +88,8 @@ dragen_umi_metrics_read <- function(x) {
     tidyr::separate_wider_delim(
       "value",
       names = c("category", "dummy1", "var", "count", "pct"),
-      delim = ",", too_few = "align_start"
+      delim = ",",
+      too_few = "align_start"
     ) |>
     dplyr::mutate(
       var = tolower(.data$var),
@@ -103,7 +109,11 @@ dragen_umi_metrics_read <- function(x) {
   d2 <- d1 |>
     dplyr::filter(!grepl("histo", .data$var)) |>
     dplyr::select("var", "count", "pct") |>
-    tidyr::pivot_longer(c("count", "pct"), names_to = "name", values_to = "value") |>
+    tidyr::pivot_longer(
+      c("count", "pct"),
+      names_to = "name",
+      values_to = "value"
+    ) |>
     dplyr::mutate(
       value = as.numeric(.data$value),
       name = dplyr::if_else(.data$name == "count", "", "_pct"),
@@ -140,7 +150,8 @@ dragen_gc_metrics_read <- function(x) {
     tidyr::separate_wider_delim(
       "value",
       names = c("category", "dummy1", "name", "value", "fraction"),
-      delim = ",", too_few = "align_start"
+      delim = ",",
+      too_few = "align_start"
     )
   abbrev_nm <- c(
     "Window size" = "window_size",
@@ -238,7 +249,8 @@ dragen_cnv_metrics_read <- function(x) {
     tidyr::separate_wider_delim(
       "value",
       names = c("category", "extra", "var", "count", "pct"),
-      delim = ",", too_few = "align_start"
+      delim = ",",
+      too_few = "align_start"
     )
   # in cttso
   sexgt <- d1 |>
@@ -294,7 +306,8 @@ dragen_sv_metrics_read <- function(x) {
     dplyr::filter(!grepl("Total number of structural variants", .data$value)) |>
     tidyr::separate_wider_delim(
       "value",
-      names = c("svsum", "sample", "var", "count", "pct"), delim = ",",
+      names = c("svsum", "sample", "var", "count", "pct"),
+      delim = ",",
       too_few = "align_start"
     ) |>
     dplyr::mutate(
@@ -323,33 +336,38 @@ dragen_trimmer_metrics_read <- function(x) {
   d0 <- readr::read_lines(x)
   assertthat::assert_that(grepl("TRIMMER STATISTICS", d0[1]))
   abbrev_nm <- c(
-    "Total input reads"                              = "reads_tot_input",
-    "Total input bases"                              = "bases_tot",
-    "Total input bases R1"                           = "bases_r1",
-    "Total input bases R2"                           = "bases_r2",
-    "Average input read length"                      = "read_len_avg",
-    "Total trimmed reads"                            = "reads_trimmed_tot",
-    "Total trimmed bases"                            = "bases_trimmed_tot",
-    "Average bases trimmed per read"                 = "bases_trimmed_avg_per_read",
-    "Average bases trimmed per trimmed read"         = "bases_trimmed_avg_per_trimmedread",
-    "Remaining poly-G K-mers R1 3prime"              = "polygkmers3r1_remaining",
-    "Remaining poly-G K-mers R2 3prime"              = "polygkmers3r2_remaining",
+    "Total input reads" = "reads_tot_input",
+    "Total input bases" = "bases_tot",
+    "Total input bases R1" = "bases_r1",
+    "Total input bases R2" = "bases_r2",
+    "Average input read length" = "read_len_avg",
+    "Total trimmed reads" = "reads_trimmed_tot",
+    "Total trimmed bases" = "bases_trimmed_tot",
+    "Average bases trimmed per read" = "bases_trimmed_avg_per_read",
+    "Average bases trimmed per trimmed read" = "bases_trimmed_avg_per_trimmedread",
+    "Remaining poly-G K-mers R1 3prime" = "polygkmers3r1_remaining",
+    "Remaining poly-G K-mers R2 3prime" = "polygkmers3r2_remaining",
     "Poly-G soft trimmed reads unfiltered R1 3prime" = "polyg_soft_trimmed_reads_unfilt_3r1",
     "Poly-G soft trimmed reads unfiltered R2 3prime" = "polyg_soft_trimmed_reads_unfilt_3r2",
-    "Poly-G soft trimmed reads filtered R1 3prime"   = "polyg_soft_trimmed_reads_filt_3r1",
-    "Poly-G soft trimmed reads filtered R2 3prime"   = "polyg_soft_trimmed_reads_filt_3r2",
+    "Poly-G soft trimmed reads filtered R1 3prime" = "polyg_soft_trimmed_reads_filt_3r1",
+    "Poly-G soft trimmed reads filtered R2 3prime" = "polyg_soft_trimmed_reads_filt_3r2",
     "Poly-G soft trimmed bases unfiltered R1 3prime" = "polyg_soft_trimmed_bases_unfilt_3r1",
     "Poly-G soft trimmed bases unfiltered R2 3prime" = "polyg_soft_trimmed_bases_unfilt_3r2",
-    "Poly-G soft trimmed bases filtered R1 3prime"   = "polyg_soft_trimmed_bases_filt_3r1",
-    "Poly-G soft trimmed bases filtered R2 3prime"   = "polyg_soft_trimmed_bases_filt_3r2",
-    "Total filtered reads"                           = "reads_tot_filt",
-    "Reads filtered for minimum read length R1"      = "reads_filt_minreadlenr1",
-    "Reads filtered for minimum read length R2"      = "reads_filt_minreadlenr2"
+    "Poly-G soft trimmed bases filtered R1 3prime" = "polyg_soft_trimmed_bases_filt_3r1",
+    "Poly-G soft trimmed bases filtered R2 3prime" = "polyg_soft_trimmed_bases_filt_3r2",
+    "Total filtered reads" = "reads_tot_filt",
+    "Reads filtered for minimum read length R1" = "reads_filt_minreadlenr1",
+    "Reads filtered for minimum read length R2" = "reads_filt_minreadlenr2"
   )
 
   d1 <- d0 |>
     tibble::as_tibble_col(column_name = "value") |>
-    tidyr::separate_wider_delim("value", names = c("category", "extra", "var", "count", "pct"), delim = ",", too_few = "align_start") |>
+    tidyr::separate_wider_delim(
+      "value",
+      names = c("category", "extra", "var", "count", "pct"),
+      delim = ",",
+      too_few = "align_start"
+    ) |>
     dplyr::mutate(
       count = as.numeric(.data$count),
       pct = round(as.numeric(.data$pct), 2),
@@ -381,6 +399,7 @@ dragen_trimmer_metrics_read <- function(x) {
 #' }
 #' @export
 dragen_vc_metrics_read <- function(x) {
+  # fmt: skip
   abbrev_nm1 <- tibble::tribble(
     ~raw, ~clean, ~region,
     "Total", "var_tot", FALSE,
@@ -419,7 +438,8 @@ dragen_vc_metrics_read <- function(x) {
     tidyr::separate_wider_delim(
       "value",
       names = c("category", "sample", "var", "count", "pct"),
-      delim = ",", too_few = "align_start"
+      delim = ",",
+      too_few = "align_start"
     )
   reg1 <- NULL
   str1 <- NULL
@@ -579,7 +599,8 @@ dragen_mapping_metrics_read <- function(x) {
     tidyr::separate_wider_delim(
       "value",
       names = c("dragen_sample", "RG", "var", "count", "pct"),
-      delim = ",", too_few = "align_start"
+      delim = ",",
+      too_few = "align_start"
     ) |>
     dplyr::mutate(
       count = dplyr::na_if(.data$count, "NA"),
@@ -588,7 +609,11 @@ dragen_mapping_metrics_read <- function(x) {
       var = dplyr::recode(.data$var, !!!abbrev_nm),
       RG = dplyr::if_else(.data$RG == "", "Total", .data$RG),
       dragen_sample = sub(reg1, "", .data$dragen_sample) |> trimws(),
-      dragen_sample = dplyr::if_else(.data$dragen_sample == "", "SINGLE", .data$dragen_sample)
+      dragen_sample = dplyr::if_else(
+        .data$dragen_sample == "",
+        "SINGLE",
+        .data$dragen_sample
+      )
     ) |>
     dplyr::select("dragen_sample", "RG", "var", "count", "pct")
   dirty_names_cleaned(unique(d$var), abbrev_nm, x)
@@ -617,6 +642,7 @@ dragen_mapping_metrics_read <- function(x) {
 #' @export
 dragen_coverage_metrics_read <- function(x) {
   # all rows except 'Aligned bases' and 'Aligned reads' refer to the region
+  # fmt: skip
   abbrev_nm <- tibble::tribble(
     ~raw, ~clean, ~region,
     "Aligned bases", "bases_aligned_tot", FALSE,
@@ -640,7 +666,8 @@ dragen_coverage_metrics_read <- function(x) {
     tibble::as_tibble_col(column_name = "value") |>
     tidyr::separate_wider_delim(
       "value",
-      delim = ",", too_few = "align_start",
+      delim = ",",
+      too_few = "align_start",
       names = c("category", "dummy1", "var", "value", "pct")
     )
   reg1 <- NULL
@@ -685,7 +712,11 @@ dragen_coverage_metrics_read <- function(x) {
       var = gsub("\\[|\\]|\\(|\\)| ", "", .data$var),
       var = gsub("x", "", .data$var)
     ) |>
-    tidyr::separate_wider_delim("var", names = c("start", "end"), delim = ":") |>
+    tidyr::separate_wider_delim(
+      "var",
+      names = c("start", "end"),
+      delim = ":"
+    ) |>
     dplyr::mutate(var = as.character(glue("cov_pct_{start}_{end}_{reg1}"))) |>
     dplyr::select("var", "value")
   res <- dplyr::bind_rows(res1, res2) |>
@@ -731,7 +762,9 @@ dragen_contig_mean_coverage_plot <- function(d, top_alt_n = 15) {
     unique()
 
   alt_panel2 <- alt_panel |>
-    dplyr::mutate(alt_group = dplyr::if_else(.data$chrom %in% top_alt, "top", "bottom"))
+    dplyr::mutate(
+      alt_group = dplyr::if_else(.data$chrom %in% top_alt, "top", "bottom")
+    )
 
   alt_panel_final <- alt_panel2 |>
     dplyr::group_by(.data$alt_group) |>
@@ -739,14 +772,24 @@ dragen_contig_mean_coverage_plot <- function(d, top_alt_n = 15) {
     dplyr::inner_join(alt_panel2, by = c("alt_group")) |>
     dplyr::mutate(
       chrom = dplyr::if_else(.data$alt_group == "bottom", "OTHER", .data$chrom),
-      coverage = dplyr::if_else(.data$alt_group == "bottom", .data$mean_cov, .data$coverage)
+      coverage = dplyr::if_else(
+        .data$alt_group == "bottom",
+        .data$mean_cov,
+        .data$coverage
+      )
     ) |>
     dplyr::distinct() |>
     dplyr::filter(.data$coverage > min_cvg) |>
     dplyr::ungroup() |>
     dplyr::select("chrom", "coverage", "panel")
 
-  chrom_fac_levels <- c(main_chrom, "chrM", "MT", top_alt[!top_alt %in% c("chrM", "MT")], "OTHER")
+  chrom_fac_levels <- c(
+    main_chrom,
+    "chrM",
+    "MT",
+    top_alt[!top_alt %in% c("chrM", "MT")],
+    "OTHER"
+  )
   d <- dplyr::bind_rows(main_panel, alt_panel_final) |>
     dplyr::mutate(chrom = factor(.data$chrom, levels = chrom_fac_levels))
 
@@ -754,13 +797,17 @@ dragen_contig_mean_coverage_plot <- function(d, top_alt_n = 15) {
     dplyr::mutate(label = "sampleA") |>
     ggplot2::ggplot(
       ggplot2::aes(
-        x = .data$chrom, y = .data$coverage, group = .data$label,
+        x = .data$chrom,
+        y = .data$coverage,
+        group = .data$label,
       )
     ) +
     ggplot2::geom_point() +
     ggplot2::geom_line() +
     ggplot2::scale_y_continuous(
-      limits = c(0, NA), expand = c(0, 0), labels = scales::comma,
+      limits = c(0, NA),
+      expand = c(0, 0),
+      labels = scales::comma,
       breaks = scales::pretty_breaks(n = 8)
     ) +
     ggplot2::theme_minimal() +
@@ -773,8 +820,17 @@ dragen_contig_mean_coverage_plot <- function(d, top_alt_n = 15) {
       panel.grid.major.y = ggplot2::element_blank(),
       strip.background = ggplot2::element_blank(),
       strip.text.x = ggplot2::element_blank(),
-      axis.text.x = ggplot2::element_text(angle = 45, vjust = 1, hjust = 1, size = 6),
-      plot.title = ggplot2::element_text(colour = "#2c3e50", size = 14, face = "bold"),
+      axis.text.x = ggplot2::element_text(
+        angle = 45,
+        vjust = 1,
+        hjust = 1,
+        size = 6
+      ),
+      plot.title = ggplot2::element_text(
+        colour = "#2c3e50",
+        size = 14,
+        face = "bold"
+      ),
       panel.spacing = ggplot2::unit(2, "lines")
     ) +
     ggplot2::facet_wrap(ggplot2::vars(.data$panel), nrow = 2, scales = "free")
@@ -808,7 +864,11 @@ dragen_ploidy_estimation_metrics_read <- function(x) {
   )
   d <- raw |>
     tibble::as_tibble_col(column_name = "value") |>
-    tidyr::separate_wider_delim("value", names = c("dummy1", "dummy2", "var", "value"), delim = ",") |>
+    tidyr::separate_wider_delim(
+      "value",
+      names = c("dummy1", "dummy2", "var", "value"),
+      delim = ","
+    ) |>
     dplyr::select("var", "value") |>
     dplyr::mutate(
       var = dplyr::recode(.data$var, !!!abbrev_nm)
@@ -859,14 +919,20 @@ dragen_ploidy_estimation_metrics_read <- function(x) {
 #' )
 #' }
 #' @export
-dtw_Wf_dragen <- function(path, prefix, outdir,
-                          outdir_tidy = file.path(outdir, "dracarys_tidy"),
-                          format = "rds",
-                          max_files = 1000,
-                          dryrun = FALSE) {
+dtw_Wf_dragen <- function(
+  path,
+  prefix,
+  outdir,
+  outdir_tidy = file.path(outdir, "dracarys_tidy"),
+  format = "rds",
+  max_files = 1000,
+  dryrun = FALSE
+) {
   obj <- Wf_dragen$new(path = path, prefix = prefix)
   d_dl <- obj$download_files(
-    outdir = outdir, max_files = max_files, dryrun = dryrun
+    outdir = outdir,
+    max_files = max_files,
+    dryrun = dryrun
   )
   if (!dryrun) {
     d_tidy <- obj$tidy_files(d_dl)
@@ -923,6 +989,7 @@ Wf_dragen <- R6::R6Class(
       wname <- "dragen"
       pref <- prefix
       tn1 <- "(|_tumor|_normal)"
+      # fmt: skip
       regexes <- tibble::tribble(
         ~regex, ~fun,
         glue("{pref}\\-replay\\.json$"), "read_replay",
@@ -964,6 +1031,7 @@ Wf_dragen <- R6::R6Class(
     #' @description Print details about the Workflow.
     #' @param ... (ignored).
     print = function(...) {
+      # fmt: skip
       res <- tibble::tribble(
         ~var, ~value,
         "path", private$.path,
@@ -980,7 +1048,12 @@ Wf_dragen <- R6::R6Class(
       res <- x |>
         jsonlite::read_json(simplifyVector = TRUE) |>
         purrr::map_if(is.data.frame, tibble::as_tibble)
-      req_elements <- c("command_line", "hash_table_build", "dragen_config", "system")
+      req_elements <- c(
+        "command_line",
+        "hash_table_build",
+        "dragen_config",
+        "system"
+      )
       assertthat::assert_that(all(names(res) %in% req_elements))
       res[["system"]] <- res[["system"]] |>
         tibble::as_tibble_row()
@@ -998,7 +1071,11 @@ Wf_dragen <- R6::R6Class(
     #' @param keep_alt Keep ALT contigs.
     read_contigMeanCov = function(x, keep_alt = FALSE) {
       subprefix <- private$dragen_subprefix(x, "_contig_mean_cov")
-      dat <- readr::read_csv(x, col_names = c("chrom", "n_bases", "coverage"), col_types = "cdd") |>
+      dat <- readr::read_csv(
+        x,
+        col_names = c("chrom", "n_bases", "coverage"),
+        col_types = "cdd"
+      ) |>
         dplyr::filter(
           if (!keep_alt) {
             !grepl("chrM|MT|_|Autosomal|HLA-|EBV|GL|hs37d5", .data$chrom)
@@ -1006,14 +1083,20 @@ Wf_dragen <- R6::R6Class(
             TRUE
           }
         )
-      tibble::tibble(name = glue("dragen_contigmeancov_{subprefix}"), data = list(dat[]))
+      tibble::tibble(
+        name = glue("dragen_contigmeancov_{subprefix}"),
+        data = list(dat[])
+      )
     },
     #' @description Read `coverage_metrics.csv` file.
     #' @param x Path to file.
     read_coverageMetrics = function(x) {
       subprefix <- private$dragen_subprefix(x, "_coverage_metrics")
       dat <- dragen_coverage_metrics_read(x)
-      tibble::tibble(name = glue("dragen_covmetrics_{subprefix}"), data = list(dat))
+      tibble::tibble(
+        name = glue("dragen_covmetrics_{subprefix}"),
+        data = list(dat)
+      )
     },
     #' @description Read `fine_hist.csv` file.
     #' @param x Path to file.
@@ -1024,11 +1107,18 @@ Wf_dragen <- R6::R6Class(
       # there's a max Depth of 2000+, so convert to numeric for easier plotting
       dat <- d |>
         dplyr::mutate(
-          Depth = ifelse(grepl("+", .data$Depth), sub("(\\d*)\\+", "\\1", .data$Depth), .data$Depth),
+          Depth = ifelse(
+            grepl("+", .data$Depth),
+            sub("(\\d*)\\+", "\\1", .data$Depth),
+            .data$Depth
+          ),
           Depth = as.integer(.data$Depth)
         ) |>
         dplyr::select(depth = "Depth", n_loci = "Overall")
-      tibble::tibble(name = glue("dragen_finehist_{subprefix}"), data = list(dat))
+      tibble::tibble(
+        name = glue("dragen_finehist_{subprefix}"),
+        data = list(dat)
+      )
     },
     #' @description Read `fragment_length_hist.csv` file.
     #' @param x Path to file.
@@ -1038,7 +1128,11 @@ Wf_dragen <- R6::R6Class(
       dat <- d |>
         tibble::enframe(name = "name", value = "value") |>
         dplyr::filter(!grepl("#Sample: |FragmentLength,Count", .data$value)) |>
-        tidyr::separate_wider_delim(cols = "value", names = c("fragment_length", "count"), delim = ",") |>
+        tidyr::separate_wider_delim(
+          cols = "value",
+          names = c("fragment_length", "count"),
+          delim = ","
+        ) |>
         dplyr::mutate(
           count = as.numeric(.data$count),
           fragmentLength = as.numeric(.data$fragment_length)
@@ -1064,7 +1158,11 @@ Wf_dragen <- R6::R6Class(
           var = gsub("x", "", .data$var),
           var = gsub("inf", "Inf", .data$var)
         ) |>
-        tidyr::separate_wider_delim("var", names = c("start", "end"), delim = ":") |>
+        tidyr::separate_wider_delim(
+          "var",
+          names = c("start", "end"),
+          delim = ":"
+        ) |>
         dplyr::mutate(
           start = as.numeric(.data$start),
           end = as.numeric(.data$end),
@@ -1078,7 +1176,9 @@ Wf_dragen <- R6::R6Class(
     read_timeMetrics = function(x) {
       cn <- c("dummy1", "dummy2", "Step", "time_hrs", "time_sec")
       ct <- readr::cols(
-        .default = "c", time_hrs = readr::col_time(format = "%T"), time_sec = "d"
+        .default = "c",
+        time_hrs = readr::col_time(format = "%T"),
+        time_sec = "d"
       )
       d <- readr::read_csv(x, col_names = cn, col_types = ct)
       assertthat::assert_that(d$dummy1[1] == "RUN TIME", is.na(d$dummy2[1]))
@@ -1099,7 +1199,10 @@ Wf_dragen <- R6::R6Class(
     read_vcMetrics = function(x) {
       subprefix <- private$dragen_subprefix(x, "_metrics")
       dat <- dragen_vc_metrics_read(x)
-      tibble::tibble(name = glue("dragen_vcmetrics_{subprefix}"), data = list(dat[]))
+      tibble::tibble(
+        name = glue("dragen_vcmetrics_{subprefix}"),
+        data = list(dat[])
+      )
     },
     #' @description Read `trimmer_metrics.csv` file.
     #' @param x Path to file.

--- a/R/dragen_fastqc.R
+++ b/R/dragen_fastqc.R
@@ -36,7 +36,11 @@ dragen_fastqc_metrics_read <- function(x) {
   # the value is an accumulation, so divide by number of grains
   pos_base_cont <- d |>
     dplyr::filter(.data$section == "POSITIONAL BASE CONTENT") |>
-    tidyr::separate_wider_delim("metric", delim = " ", names = c("readpos", "pos", "base", "bases")) |>
+    tidyr::separate_wider_delim(
+      "metric",
+      delim = " ",
+      names = c("readpos", "pos", "base", "bases")
+    ) |>
     dplyr::mutate(
       is_binned = grepl("-", .data$pos), # for debugging
       bin_group = dplyr::row_number()
@@ -59,7 +63,11 @@ dragen_fastqc_metrics_read <- function(x) {
   # the value is an avg, so keep same between grains
   pos_base_mean_qual <- d |>
     dplyr::filter(.data$section == "POSITIONAL BASE MEAN QUALITY") |>
-    tidyr::separate_wider_delim("metric", delim = " ", names = c("readpos", "pos", "base", "avg", "qual")) |>
+    tidyr::separate_wider_delim(
+      "metric",
+      delim = " ",
+      names = c("readpos", "pos", "base", "avg", "qual")
+    ) |>
     tidyr::separate_longer_delim("pos", delim = "-") |>
     dplyr::mutate(pos = as.integer(.data$pos), value = round(.data$value, 2)) |>
     dplyr::select("mate", "pos", "base", "value")
@@ -68,28 +76,50 @@ dragen_fastqc_metrics_read <- function(x) {
   # keep same value between grains
   pos_qual <- d |>
     dplyr::filter(.data$section == "POSITIONAL QUALITY") |>
-    tidyr::separate_wider_delim("metric", delim = " ", names = c("readpos", "pos", "pct", "quant", "qv")) |>
+    tidyr::separate_wider_delim(
+      "metric",
+      delim = " ",
+      names = c("readpos", "pos", "pct", "quant", "qv")
+    ) |>
     tidyr::separate_longer_delim("pos", delim = "-") |>
-    dplyr::mutate(pct = as.integer(sub("%", "", .data$pct)), pos = as.integer(.data$pos)) |>
+    dplyr::mutate(
+      pct = as.integer(sub("%", "", .data$pct)),
+      pos = as.integer(.data$pos)
+    ) |>
     dplyr::select("mate", "pos", "pct", "value")
 
   gc_cont <- d |>
     dplyr::filter(.data$section == "READ GC CONTENT") |>
-    tidyr::separate_wider_delim("metric", delim = " ", names = c("pct", "GC", "reads")) |>
+    tidyr::separate_wider_delim(
+      "metric",
+      delim = " ",
+      names = c("pct", "GC", "reads")
+    ) |>
     dplyr::mutate(pct = as.integer(sub("%", "", .data$pct))) |>
     dplyr::select("mate", "pct", "value")
 
   gc_cont_qual <- d |>
     dplyr::filter(.data$section == "READ GC CONTENT QUALITY") |>
-    tidyr::separate_wider_delim("metric", delim = " ", names = c("pct", "GC", "reads", "avg", "qual")) |>
-    dplyr::mutate(pct = as.integer(sub("%", "", .data$pct)), value = round(.data$value, 2)) |>
+    tidyr::separate_wider_delim(
+      "metric",
+      delim = " ",
+      names = c("pct", "GC", "reads", "avg", "qual")
+    ) |>
+    dplyr::mutate(
+      pct = as.integer(sub("%", "", .data$pct)),
+      value = round(.data$value, 2)
+    ) |>
     dplyr::select("mate", "pct", "value")
 
   # there are binned bp e.g. "149-150"
   # the value is an accumulation, so divide by number of grains
   read_len <- d |>
     dplyr::filter(.data$section == "READ LENGTHS") |>
-    tidyr::separate_wider_delim("metric", delim = " ", names = c("bp", "len", "reads")) |>
+    tidyr::separate_wider_delim(
+      "metric",
+      delim = " ",
+      names = c("bp", "len", "reads")
+    ) |>
     dplyr::mutate(
       bp = sub("bp", "", .data$bp),
       is_binned = grepl("-", .data$bp), # for debugging
@@ -105,7 +135,11 @@ dragen_fastqc_metrics_read <- function(x) {
 
   read_mean_qual <- d |>
     dplyr::filter(.data$section == "READ MEAN QUALITY") |>
-    tidyr::separate_wider_delim("metric", delim = " ", names = c("q", "reads")) |>
+    tidyr::separate_wider_delim(
+      "metric",
+      delim = " ",
+      names = c("q", "reads")
+    ) |>
     dplyr::mutate(q = as.integer(sub("Q", "", .data$q))) |>
     dplyr::select("mate", "q", "value")
 
@@ -113,7 +147,11 @@ dragen_fastqc_metrics_read <- function(x) {
   # keep same value between grains
   seq_pos <- d |>
     dplyr::filter(.data$section == "SEQUENCE POSITIONS") |>
-    tidyr::separate_wider_delim("metric", delim = " ", names = c("seq", "bp", "starts")) |>
+    tidyr::separate_wider_delim(
+      "metric",
+      delim = " ",
+      names = c("seq", "bp", "starts")
+    ) |>
     dplyr::mutate(bp = sub("bp", "", .data$bp)) |>
     tidyr::separate_longer_delim("bp", delim = "-") |>
     dplyr::mutate(bp = as.integer(.data$bp)) |>

--- a/R/fs_local.R
+++ b/R/fs_local.R
@@ -44,7 +44,11 @@ local_list_files_dir <- function(localdir, max_files = NULL) {
 #' @testexamples
 #' expect_equal(nrow(x), 1)
 #' @export
-local_list_files_filter_relevant <- function(localdir, regexes = DR_FILE_REGEX, max_files = NULL) {
+local_list_files_filter_relevant <- function(
+  localdir,
+  regexes = DR_FILE_REGEX,
+  max_files = NULL
+) {
   local_list_files_dir(localdir = localdir, max_files = max_files) |>
     dplyr::mutate(
       type = purrr::map_chr(.data$path, \(x) match_regex(x, regexes = regexes))

--- a/R/multiqc.R
+++ b/R/multiqc.R
@@ -46,7 +46,13 @@ MultiqcFile <- R6::R6Class(
     #' @param out_format Format of output file(s) (one of 'tsv' (def.),
     #' 'parquet', 'both').
     #' @param drid dracarys ID to use for the dataset (e.g. `wfrid.123`, `prid.456`).
-    write = function(d, out_dir = NULL, prefix, out_format = "tsv", drid = NULL) {
+    write = function(
+      d,
+      out_dir = NULL,
+      prefix,
+      out_format = "tsv",
+      drid = NULL
+    ) {
       if (!is.null(out_dir)) {
         prefix <- file.path(out_dir, prefix)
       }
@@ -54,7 +60,12 @@ MultiqcFile <- R6::R6Class(
       # only write plots if output format is rds, else need to destructure the whole thing...
       has_plots_and_not_rds <- !inherits(d, "data.frame") && out_format != "rds"
       assertthat::assert_that(!has_plots_and_not_rds)
-      write_dracarys(obj = d, prefix = prefix, out_format = out_format, drid = drid)
+      write_dracarys(
+        obj = d,
+        prefix = prefix,
+        out_format = out_format,
+        drid = drid
+      )
     }
   )
 )
@@ -100,7 +111,12 @@ multiqc_tidy_json <- function(j) {
       config_creation_date = cdate,
       umccr_workflow = workflow
     ) |>
-    dplyr::select("umccr_id", "umccr_workflow", "config_creation_date", dplyr::everything())
+    dplyr::select(
+      "umccr_id",
+      "umccr_workflow",
+      "config_creation_date",
+      dplyr::everything()
+    )
 
   if (workflow == "dragen_transcriptome") {
     # discard Ref_X control samples
@@ -110,7 +126,10 @@ multiqc_tidy_json <- function(j) {
   } else if (workflow %in% c("dragen_umccrise", "bcbio_umccrise")) {
     # discard Alice, Bob etc. control samples
     um_ref_samples <- c("Alice", "Bob", "Chen", "Elon", "Dakota")
-    um_ref_samples <- paste0(um_ref_samples, rep(c("_T", "_B", ""), each = length(um_ref_samples)))
+    um_ref_samples <- paste0(
+      um_ref_samples,
+      rep(c("_T", "_B", ""), each = length(um_ref_samples))
+    )
     d <- d |>
       dplyr::filter(!.data$umccr_id %in% um_ref_samples)
   }
@@ -119,10 +138,15 @@ multiqc_tidy_json <- function(j) {
 
 multiqc_rename_cols <- function(d) {
   umccr_workflows <- c(
-    "dragen_alignment", "dragen_somatic",
-    "dragen_transcriptome", "dragen_umccrise",
-    "dragen_ctdna", "dragen_sash",
-    "bcbio_umccrise", "bcbio_wgs", "bcbio_wts"
+    "dragen_alignment",
+    "dragen_somatic",
+    "dragen_transcriptome",
+    "dragen_umccrise",
+    "dragen_ctdna",
+    "dragen_sash",
+    "bcbio_umccrise",
+    "bcbio_wgs",
+    "bcbio_wts"
   )
 
   w <- unique(d[["umccr_workflow"]])
@@ -151,7 +175,9 @@ multiqc_rename_cols <- function(d) {
 }
 
 .multiqc_guess_workflow <- function(p) {
-  assertthat::assert_that(all(c("config_title", "report_data_sources") %in% names(p)))
+  assertthat::assert_that(all(
+    c("config_title", "report_data_sources") %in% names(p)
+  ))
   config_title <- p[["config_title"]] %||% "Unknown"
   ds <- names(p[["report_data_sources"]])
   # bcbio
@@ -161,7 +187,9 @@ multiqc_rename_cols <- function(d) {
       return("bcbio_wts")
     } else if (all(c("PURPLE", "Conpair", "mosdepth") %in% ds)) {
       return("bcbio_umccrise")
-    } else if (all(c("Samtools", "Bcftools (somatic)", "Bcftools (germline)") %in% ds)) {
+    } else if (
+      all(c("Samtools", "Bcftools (somatic)", "Bcftools (germline)") %in% ds)
+    ) {
       return("bcbio_wgs")
     } else {
       warning(glue(
@@ -177,7 +205,11 @@ multiqc_rename_cols <- function(d) {
     if (all(c("PURPLE", "Conpair", "mosdepth") %in% ds)) {
       return("dragen_umccrise")
     } else if (grepl("^UMCCR MultiQC Dragen", config_title)) {
-      w <- tolower(sub("UMCCR MultiQC Dragen (.*) Report for .*", "\\1", config_title))
+      w <- tolower(sub(
+        "UMCCR MultiQC Dragen (.*) Report for .*",
+        "\\1",
+        config_title
+      ))
       if (w == "somatic and germline") {
         w <- "somatic"
       }
@@ -188,9 +220,12 @@ multiqc_rename_cols <- function(d) {
     } else if (
       all(
         c(
-          "PURPLE", "DRAGEN-FastQC",
-          "Bcftools stats (somatic)", "Bcftools stats (germline)"
-        ) %in% ds
+          "PURPLE",
+          "DRAGEN-FastQC",
+          "Bcftools stats (somatic)",
+          "Bcftools stats (germline)"
+        ) %in%
+          ds
       )
     ) {
       return("dragen_sash")
@@ -269,23 +304,38 @@ multiqc_parse_raw <- function(p) {
 multiqc_parse_raw_interop <- function(p) {
   x <- p[["report_saved_raw_data"]]
   tool_nms <- names(x)
-  assertthat::assert_that(length(tool_nms) == 1, tool_nms == "interop_runsummary")
+  assertthat::assert_that(
+    length(tool_nms) == 1,
+    tool_nms == "interop_runsummary"
+  )
   res <- list()
   d <- x[[tool_nms]]
   assertthat::assert_that(length(d) == 1, names(d) == "interop")
   d <- d[["interop"]]
-  assertthat::assert_that(length(d) == 2, all(names(d) %in% c("summary", "details")))
+  assertthat::assert_that(
+    length(d) == 2,
+    all(names(d) %in% c("summary", "details"))
+  )
   # read metrics summary
   d_sumy <- d[["summary"]] |>
     purrr::map(\(x) unlist(x) |> tibble::as_tibble_row()) |>
     dplyr::bind_rows(.id = "Read")
   # read metrics per lane
   dbl_cols <- c(
-    "Tiles", "Density", "Cluster PF",
-    "Reads", "Reads PF", "%>=Q30",
-    "Yield", "Aligned", "Error",
-    "Error (35)", "Error (75)", "Error (100)",
-    "% Occupied", "Intensity C1"
+    "Tiles",
+    "Density",
+    "Cluster PF",
+    "Reads",
+    "Reads PF",
+    "%>=Q30",
+    "Yield",
+    "Aligned",
+    "Error",
+    "Error (35)",
+    "Error (75)",
+    "Error (100)",
+    "% Occupied",
+    "Intensity C1"
   )
   d_det <- d[["details"]] |>
     purrr::discard(\(x) length(x) == 0) |>
@@ -296,7 +346,10 @@ multiqc_parse_raw_interop <- function(p) {
     dplyr::bind_rows(.id = "Lane-Read") |>
     dplyr::arrange(.data$`Lane-Read`) |>
     dplyr::mutate(dplyr::across(dplyr::all_of(dbl_cols), .fns = as.numeric)) |>
-    dplyr::mutate(dplyr::across(dplyr::all_of(dbl_cols), ~ replace(.x, is.nan(.x), NA_real_)))
+    dplyr::mutate(dplyr::across(
+      dplyr::all_of(dbl_cols),
+      ~ replace(.x, is.nan(.x), NA_real_)
+    ))
   list(
     summary = d_sumy,
     per_lane = d_det
@@ -316,7 +369,10 @@ multiqc_kv_map <- function(l, func, map_keys = FALSE) {
 # Tibble with three columns: workflow name, raw and cleaned multiqc metric name.
 # For consistency, make sure that names are in snake_case and that the tool that
 # generates them is added as the suffix e.g. awesome_metric_tool1.
-MULTIQC_COLUMNS <- system.file("extdata/multiqc_column_map.tsv", package = "dracarys") |>
+MULTIQC_COLUMNS <- system.file(
+  "extdata/multiqc_column_map.tsv",
+  package = "dracarys"
+) |>
   readr::read_tsv(col_types = "ccc")
 
 
@@ -414,7 +470,9 @@ multiqc_parse_plots <- function(j, plot_names = NULL) {
     dplyr::rowwise() |>
     dplyr::mutate(
       input = list(plot_data[[.data$plot_nm]]),
-      plot_res = list(dr_func_eval(f = funcs[.data$plot_type], v = funcs)(.data$input))
+      plot_res = list(dr_func_eval(f = funcs[.data$plot_type], v = funcs)(
+        .data$input
+      ))
     ) |>
     dplyr::ungroup() |>
     dplyr::select(dplyr::all_of(final_cols))
@@ -433,12 +491,18 @@ multiqc_parse_plots <- function(j, plot_names = NULL) {
 #' @export
 multiqc_parse_xyline_plot <- function(dat) {
   assertthat::assert_that(dat[["plot_type"]] == "xy_line")
-  if (dat[["config"]][["id"]] %in% c("dragen_coverage_per_contig", "dragen_coverage_per_non_main_contig")) {
+  if (
+    dat[["config"]][["id"]] %in%
+      c("dragen_coverage_per_contig", "dragen_coverage_per_non_main_contig")
+  ) {
     return(multiqc_parse_xyline_plot_contig_cvg(dat))
   }
   # some empty fastqc_adapter_content_plot - see https://github.com/umccr/dracarys/issues/104
   # also empty fastqc_per_base_sequence_quality_plot
-  if (length(dat[["datasets"]][[1]]) == 0 || length(dat$datasets[[1]][["data"]]) == 0) {
+  if (
+    length(dat[["datasets"]][[1]]) == 0 ||
+      length(dat$datasets[[1]][["data"]]) == 0
+  ) {
     return(NULL)
   }
   dat[["datasets"]][[1]] |>
@@ -447,7 +511,12 @@ multiqc_parse_xyline_plot <- function(dat) {
         name <- nm_data[["name"]]
         d <- nm_data[["data"]] |>
           # handle NULLs in raw JSON
-          purrr::map(~ tibble::tibble(x = unlist(.x[1]) %||% NA_real_, y = unlist(.x[2]) %||% NA_real_)) |>
+          purrr::map(
+            ~ tibble::tibble(
+              x = unlist(.x[1]) %||% NA_real_,
+              y = unlist(.x[2]) %||% NA_real_
+            )
+          ) |>
           dplyr::bind_rows()
         tibble::tibble(name = name, x = d[["x"]], y = d[["y"]])
       }
@@ -465,7 +534,8 @@ multiqc_parse_xyline_plot <- function(dat) {
 multiqc_parse_xyline_plot_contig_cvg <- function(dat) {
   assertthat::assert_that(dat[["plot_type"]] == "xy_line")
   assertthat::assert_that(
-    dat[["config"]][["id"]] %in% c("dragen_coverage_per_contig", "dragen_coverage_per_non_main_contig")
+    dat[["config"]][["id"]] %in%
+      c("dragen_coverage_per_contig", "dragen_coverage_per_non_main_contig")
   )
   contig <- dat[["config"]][["categories"]]
   dat[["datasets"]][[1]] |>

--- a/R/regex.R
+++ b/R/regex.R
@@ -28,6 +28,7 @@ match_regex <- function(x, regexes = DR_FILE_REGEX) {
   return(NA_character_)
 }
 
+# fmt: skip
 DR_FILE_REGEX <- tibble::tribble(
   ~regex, ~fun,
   "AlignCollapseFusionCaller_metrics\\.json\\.gz$", "TsoAlignCollapseFusionCallerMetricsFile",

--- a/R/sash.R
+++ b/R/sash.R
@@ -80,11 +80,16 @@ Wf_sash <- R6::R6Class(
     #' @param SubjectID The SubjectID of the sample.
     #' @param SampleID_tumor The SampleID of the tumor sample.
     #' @param SampleID_normal The SampleID of the normal sample.
-    initialize = function(path = NULL, SubjectID = NULL, SampleID_tumor = NULL,
-                          SampleID_normal = NULL) {
+    initialize = function(
+      path = NULL,
+      SubjectID = NULL,
+      SampleID_tumor = NULL,
+      SampleID_normal = NULL
+    ) {
       wname <- "sash"
       pref <- glue("{SubjectID}_{SampleID_tumor}")
       crep <- "cancer_report/cancer_report_tables"
+      # fmt: skip
       regexes <- tibble::tribble(
         ~regex, ~fun,
         glue("{path}/{pref}/{crep}/hrd/{pref}-chord\\.tsv\\.gz$"), "read_hrdChord",
@@ -114,6 +119,7 @@ Wf_sash <- R6::R6Class(
     #' @description Print details about the Workflow.
     #' @param ... (ignored).
     print = function(...) {
+      # fmt: skip
       res <- tibble::tribble(
         ~var, ~value,
         "path", private$.path,
@@ -201,22 +207,35 @@ Wf_sash <- R6::R6Class(
         tidyr::pivot_wider(names_from = "variable", values_from = "value") |>
         dplyr::rename(MSI_mb_tmp = "MSI (indels/Mb)") |>
         dplyr::mutate(
-          purity_hmf = sub("(.*) \\(.*\\)", "\\1", .data$Purity) |> as.numeric(),
-          ploidy_hmf = sub("(.*) \\(.*\\)", "\\1", .data$Ploidy) |> as.numeric(),
-          msi_mb_hmf = sub(".* \\((.*)\\)", "\\1", .data$MSI_mb_tmp) |> as.numeric(),
+          purity_hmf = sub("(.*) \\(.*\\)", "\\1", .data$Purity) |>
+            as.numeric(),
+          ploidy_hmf = sub("(.*) \\(.*\\)", "\\1", .data$Ploidy) |>
+            as.numeric(),
+          msi_mb_hmf = sub(".* \\((.*)\\)", "\\1", .data$MSI_mb_tmp) |>
+            as.numeric(),
           contamination_hmf = as.numeric(.data$Contamination),
           deleted_genes_hmf = as.numeric(.data$DeletedGenes),
           msi_hmf = sub("(.*) \\(.*\\)", "\\1", .data$MSI_mb_tmp),
           tmb_hmf = sub("(.*) \\(.*\\)", "\\1", .data$TMB) |> as.numeric(),
           tml_hmf = sub("(.*) \\(.*\\)", "\\1", .data$TML) |> as.numeric(),
-          hypermutated = ifelse("Hypermutated" %in% d$variable, .data[["Hypermutated"]], NA) |> as.character()
+          hypermutated = ifelse(
+            "Hypermutated" %in% d$variable,
+            .data[["Hypermutated"]],
+            NA
+          ) |>
+            as.character()
         ) |>
         dplyr::select(
           qc_status_hmf = "QC_Status",
           sex_hmf = "Gender",
-          "purity_hmf", "ploidy_hmf", "msi_hmf", "msi_mb_hmf",
+          "purity_hmf",
+          "ploidy_hmf",
+          "msi_hmf",
+          "msi_mb_hmf",
           "contamination_hmf",
-          "deleted_genes_hmf", "tmb_hmf", "tml_hmf",
+          "deleted_genes_hmf",
+          "tmb_hmf",
+          "tml_hmf",
           wgd_hmf = "WGD",
           "hypermutated"
         )
@@ -259,19 +278,30 @@ Wf_sash <- R6::R6Class(
 #' )
 #' }
 #' @export
-Wf_sash_download_tidy_write <- function(path, SubjectID, SampleID_tumor, SampleID_normal,
-                                        outdir, format = "rds", max_files = 1000,
-                                        regexes = NULL, dryrun = FALSE) {
+Wf_sash_download_tidy_write <- function(
+  path,
+  SubjectID,
+  SampleID_tumor,
+  SampleID_normal,
+  outdir,
+  format = "rds",
+  max_files = 1000,
+  regexes = NULL,
+  dryrun = FALSE
+) {
   s <- Wf_sash$new(
-    path = path, SubjectID = SubjectID,
-    SampleID_tumor = SampleID_tumor, SampleID_normal = SampleID_normal
+    path = path,
+    SubjectID = SubjectID,
+    SampleID_tumor = SampleID_tumor,
+    SampleID_normal = SampleID_normal
   )
   if (!is.null(regexes)) {
     s$regexes <- regexes
   }
   d_dl <- s$download_files(
     outdir = outdir,
-    max_files = max_files, dryrun = dryrun
+    max_files = max_files,
+    dryrun = dryrun
   )
   if (!dryrun) {
     d_tidy <- s$tidy_files(d_dl)

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -44,12 +44,16 @@ tidy_files <- function(x, envir = parent.frame()) {
         !grepl("DOWNLOAD_ONLY", .data$type),
         list(
           dr_func_eval(
-            f = .data$type, v = .data$type, envir = envir
+            f = .data$type,
+            v = .data$type,
+            envir = envir
           )(.data$localpath)
         ),
         list(
           dr_func_eval(
-            f = "DOWNLOAD_ONLY", v = "DOWNLOAD_ONLY", envir = envir
+            f = "DOWNLOAD_ONLY",
+            v = "DOWNLOAD_ONLY",
+            envir = envir
           )(.data$localpath, extract_download_suffix(.data$type))
         )
       )
@@ -97,9 +101,16 @@ tidy_files <- function(x, envir = parent.frame()) {
 #' umccr_tidy(in_dir = in_dir, out_dir = out_dir, prefix = prefix, dryrun = F)
 #' }
 #' @export
-umccr_tidy <- function(in_dir = NULL, out_dir = NULL, prefix = NULL,
-                       local_dir = NULL, out_format = "tsv",
-                       dryrun = FALSE, pattern = NULL, regexes = DR_FILE_REGEX) {
+umccr_tidy <- function(
+  in_dir = NULL,
+  out_dir = NULL,
+  prefix = NULL,
+  local_dir = NULL,
+  out_format = "tsv",
+  dryrun = FALSE,
+  pattern = NULL,
+  regexes = DR_FILE_REGEX
+) {
   assertthat::assert_that(!is.null(in_dir), !is.null(out_dir), !is.null(prefix))
   dr_output_format_valid(out_format)
   e <- emojifont::emoji
@@ -107,11 +118,14 @@ umccr_tidy <- function(in_dir = NULL, out_dir = NULL, prefix = NULL,
   if (grepl("^s3://", in_dir)) {
     # in_dir is s3
     cloud_type <- "s3"
-    local_dir <- local_dir %||% file.path(out_dir, glue("dracarys_{cloud_type}_sync"))
+    local_dir <- local_dir %||%
+      file.path(out_dir, glue("dracarys_{cloud_type}_sync"))
     pat <- pattern %||% ".*" # keep all recognisable files
     dr_s3_download(
-      s3dir = in_dir, outdir = local_dir,
-      pattern = pat, dryrun = dryrun
+      s3dir = in_dir,
+      outdir = local_dir,
+      pattern = pat,
+      dryrun = dryrun
     )
     # Now use the downloaded results
     in_dir <- local_dir
@@ -125,14 +139,19 @@ umccr_tidy <- function(in_dir = NULL, out_dir = NULL, prefix = NULL,
     }
   }
   if (dryrun) {
-    cli::cli_inform("{e('camel')} You have specified 'dryrun' - just listing files!")
+    cli::cli_inform(
+      "{e('camel')} You have specified 'dryrun' - just listing files!"
+    )
     return(NULL)
   } else {
     d <- fs::dir_ls(in_dir, recurse = TRUE) |>
       tibble::as_tibble_col(column_name = "path") |>
       dplyr::mutate(
         bname = basename(.data$path),
-        type = purrr::map_chr(.data$bname, \(x) match_regex(x, regexes = regexes))
+        type = purrr::map_chr(
+          .data$bname,
+          \(x) match_regex(x, regexes = regexes)
+        )
       ) |>
       dplyr::filter(!is.na(.data$type))
 
@@ -148,12 +167,18 @@ umccr_tidy <- function(in_dir = NULL, out_dir = NULL, prefix = NULL,
     }
     dups <- dup_ftypes(d)
     if (dups$has_dup_ftypes) {
-      cli::cli_alert_danger("Aborting - the input dir {.file {in_dir}} contains duplicated file types. See JSON below:")
+      cli::cli_alert_danger(
+        "Aborting - the input dir {.file {in_dir}} contains duplicated file types. See JSON below:"
+      )
       print(dups$msg_json)
-      cli::cli_abort("Aborting - the input dir {.file {in_dir}} contains duplicated file types. See JSON above!")
+      cli::cli_abort(
+        "Aborting - the input dir {.file {in_dir}} contains duplicated file types. See JSON above!"
+      )
     }
   }
-  cli::cli_alert_info("{date_log()} {e('dragon')} {.emph {prefix}}: Start tidying UMCCR dir: {.file {in_dir}}")
+  cli::cli_alert_info(
+    "{date_log()} {e('dragon')} {.emph {prefix}}: Start tidying UMCCR dir: {.file {in_dir}}"
+  )
   res <- d |>
     dplyr::select("type", "path", "bname") |>
     dplyr::filter(!.data$type %in% FILES_DOWNLOAD_BUT_IGNORE) |>
@@ -166,20 +191,32 @@ umccr_tidy <- function(in_dir = NULL, out_dir = NULL, prefix = NULL,
         .data$type == "MultiqcFile",
         list(.data$obj$read(plot = TRUE, plot_names = "everything")),
         ifelse(
-          .data$type %in% c(
-            "TsoMergedSmallVariantsVcfFile",
-            "TsoMergedSmallVariantsGenomeVcfFile",
-            "TsoCopyNumberVariantsVcfFile"
-          ),
+          .data$type %in%
+            c(
+              "TsoMergedSmallVariantsVcfFile",
+              "TsoMergedSmallVariantsGenomeVcfFile",
+              "TsoCopyNumberVariantsVcfFile"
+            ),
           list(.data$obj$read(only_pass = FALSE)),
           list(.data$obj$read())
         )
       ),
-      obj_parsed2 = list(.data$obj$write(.data$obj_parsed, out_dir = out_dir, prefix = glue("{prefix}_{.data$type}"), out_format = out_format)),
-      plot = ifelse(.data$has_plot, list(.data$obj$plot(.data$obj_parsed)), list(NULL))
+      obj_parsed2 = list(.data$obj$write(
+        .data$obj_parsed,
+        out_dir = out_dir,
+        prefix = glue("{prefix}_{.data$type}"),
+        out_format = out_format
+      )),
+      plot = ifelse(
+        .data$has_plot,
+        list(.data$obj$plot(.data$obj_parsed)),
+        list(NULL)
+      )
     ) |>
     dplyr::select("type", "path", "obj", dat = "obj_parsed", "plot")
-  cli::cli_alert_success("{date_log()} {e('tada')} {.emph {prefix}}: UMCCR tidy results at: {.file {out_dir}}")
+  cli::cli_alert_success(
+    "{date_log()} {e('tada')} {.emph {prefix}}: UMCCR tidy results at: {.file {out_dir}}"
+  )
   return(invisible(res))
 }
 

--- a/R/tso.R
+++ b/R/tso.R
@@ -38,6 +38,7 @@ Wf_tso_ctdna_tumor_only <- R6::R6Class(
     initialize = function(path = NULL, prefix = NULL) {
       wname <- "tso_ctdna_tumor_only"
       pref <- prefix
+      # fmt: skip
       regexes <- tibble::tribble(
         ~regex, ~fun,
         glue("{pref}/{pref}.SampleAnalysisResults\\.json\\.gz$"), "sar",
@@ -67,6 +68,7 @@ Wf_tso_ctdna_tumor_only <- R6::R6Class(
     #' @description Print details about the Workflow.
     #' @param ... (ignored).
     print = function(...) {
+      # fmt: skip
       res <- tibble::tribble(
         ~var, ~value,
         "path", self$path,
@@ -197,15 +199,20 @@ Wf_tso_ctdna_tumor_only <- R6::R6Class(
 #' )
 #' }
 #' @export
-dtw_Wf_tso_ctdna_tumor_only <- function(path, prefix, outdir,
-                                        outdir_tidy = file.path(outdir, "dracarys_tidy"),
-                                        format = "rds",
-                                        max_files = 1000,
-                                        dryrun = FALSE) {
+dtw_Wf_tso_ctdna_tumor_only <- function(
+  path,
+  prefix,
+  outdir,
+  outdir_tidy = file.path(outdir, "dracarys_tidy"),
+  format = "rds",
+  max_files = 1000,
+  dryrun = FALSE
+) {
   obj <- Wf_tso_ctdna_tumor_only$new(path = path, prefix = prefix)
   d_dl <- obj$download_files(
     outdir = outdir,
-    max_files = max_files, dryrun = dryrun
+    max_files = max_files,
+    dryrun = dryrun
   )
   if (!dryrun) {
     d_tidy <- obj$tidy_files(d_dl)
@@ -230,11 +237,17 @@ dtw_Wf_tso_ctdna_tumor_only <- function(path, prefix, outdir,
 #' @export
 tso_combinedvaro_smallv_read <- function(x) {
   nm_map <- c(
-    gene = "Gene", chrom = "Chromosome", pos = "Genomic Position",
-    ref = "Reference Call", alt = "Alternative Call",
-    vaf = "Allele Frequency", dp = "Depth",
-    pdot = "P-Dot Notation", cdot = "C-Dot Notation",
-    csq = "Consequence(s)", exons = "Affected Exon(s)"
+    gene = "Gene",
+    chrom = "Chromosome",
+    pos = "Genomic Position",
+    ref = "Reference Call",
+    alt = "Alternative Call",
+    vaf = "Allele Frequency",
+    dp = "Depth",
+    pdot = "P-Dot Notation",
+    cdot = "C-Dot Notation",
+    csq = "Consequence(s)",
+    exons = "Affected Exon(s)"
   )
   # read full file
   ln <- readr::read_lines(x, skip_empty_rows = TRUE)
@@ -247,7 +260,8 @@ tso_combinedvaro_smallv_read <- function(x) {
   d <- ln[(smallv + 1):length(ln)] |>
     I() |> # read parsed data as-is
     readr::read_tsv(
-      col_names = TRUE, col_types = readr::cols(
+      col_names = TRUE,
+      col_types = readr::cols(
         .default = "c",
         "Genomic Position" = "i",
         "Allele Frequency" = "d",
@@ -270,26 +284,56 @@ tso_combinedvaro_smallv_read <- function(x) {
 #' @export
 tso_tmbt_read <- function(x) {
   ct <- list(
-    Chromosome = "c", Position = "d", RefCall = "c", AltCall = "c",
-    VAF = "d", Depth = "d", CytoBand = "c", GeneName = "c",
-    VariantType = "c", CosmicIDs = "c", MaxCosmicCount = "d",
-    AlleleCountsGnomadExome = "d", AlleleCountsGnomadGenome = "d",
-    AlleleCounts1000Genomes = "d", MaxDatabaseAlleleCounts = "d",
-    GermlineFilterDatabase = "c", GermlineFilterProxi = "c",
-    CodingVariant = "c", Nonsynonymous = "c", IncludedInTMBNumerator = "c"
+    Chromosome = "c",
+    Position = "d",
+    RefCall = "c",
+    AltCall = "c",
+    VAF = "d",
+    Depth = "d",
+    CytoBand = "c",
+    GeneName = "c",
+    VariantType = "c",
+    CosmicIDs = "c",
+    MaxCosmicCount = "d",
+    AlleleCountsGnomadExome = "d",
+    AlleleCountsGnomadGenome = "d",
+    AlleleCounts1000Genomes = "d",
+    MaxDatabaseAlleleCounts = "d",
+    GermlineFilterDatabase = "c",
+    GermlineFilterProxi = "c",
+    CodingVariant = "c",
+    Nonsynonymous = "c",
+    IncludedInTMBNumerator = "c"
   )
   # cttso v2 has introduced a few extra columns
   ct2 <- list(
-    Chromosome = "c", Position = "d", RefCall = "c", AltCall = "c",
-    VAF = "d", Depth = "d", CytoBand = "c", GeneName = "c",
-    VariantType = "c", CosmicIDs = "c", MaxCosmicCount = "d",
-    ClinVarIDs = "c", ClinVarSignificance = "c",
-    AlleleCountsGnomadExome = "d", AlleleCountsGnomadGenome = "d",
-    AlleleCounts1000Genomes = "d", MaxDatabaseAlleleCounts = "d",
-    GermlineFilterDatabase = "c", GermlineFilterProxi = "c",
-    Nonsynonymous = "c", withinValidTmbRegion = "c",
-    IncludedInTMBNumerator = "c", Status = "c", ProteinChange = "c",
-    CDSChange = "c", Exons = "c", Consequence = "c"
+    Chromosome = "c",
+    Position = "d",
+    RefCall = "c",
+    AltCall = "c",
+    VAF = "d",
+    Depth = "d",
+    CytoBand = "c",
+    GeneName = "c",
+    VariantType = "c",
+    CosmicIDs = "c",
+    MaxCosmicCount = "d",
+    ClinVarIDs = "c",
+    ClinVarSignificance = "c",
+    AlleleCountsGnomadExome = "d",
+    AlleleCountsGnomadGenome = "d",
+    AlleleCounts1000Genomes = "d",
+    MaxDatabaseAlleleCounts = "d",
+    GermlineFilterDatabase = "c",
+    GermlineFilterProxi = "c",
+    Nonsynonymous = "c",
+    withinValidTmbRegion = "c",
+    IncludedInTMBNumerator = "c",
+    Status = "c",
+    ProteinChange = "c",
+    CDSChange = "c",
+    Exons = "c",
+    Consequence = "c"
   )
   hdr <- readr::read_tsv(x, n_max = 0, show_col_types = FALSE)
   if (all(names(ct2) %in% colnames(hdr))) {
@@ -353,11 +397,17 @@ tso_targetregcvg_plot <- function(d, min_pct = 2) {
     dplyr::select(dp = "ConsensusReadDepth", pct = "Percentage") |>
     dplyr::mutate(dp = as.numeric(sub("X", "", .data$dp)))
   d |>
-    ggplot2::ggplot(ggplot2::aes(x = .data$dp, y = .data$pct, label = .data$dp)) +
+    ggplot2::ggplot(ggplot2::aes(
+      x = .data$dp,
+      y = .data$pct,
+      label = .data$dp
+    )) +
     ggplot2::geom_point() +
     ggplot2::geom_line() +
     ggrepel::geom_text_repel() +
-    ggplot2::labs(title = "Percentage of Target Region Covered by Given Read Depth") +
+    ggplot2::labs(
+      title = "Percentage of Target Region Covered by Given Read Depth"
+    ) +
     ggplot2::xlab("Depth") +
     ggplot2::ylab("Percentage") +
     ggplot2::theme_minimal() +
@@ -365,7 +415,11 @@ tso_targetregcvg_plot <- function(d, min_pct = 2) {
       legend.position = c(0.9, 0.9),
       legend.justification = c(1, 1),
       panel.grid.minor = ggplot2::element_blank(),
-      plot.title = ggplot2::element_text(colour = "#2c3e50", size = 14, face = "bold")
+      plot.title = ggplot2::element_text(
+        colour = "#2c3e50",
+        size = 14,
+        face = "bold"
+      )
     )
 }
 
@@ -382,10 +436,23 @@ tso_targetregcvg_plot <- function(d, min_pct = 2) {
 tso_fusions_read <- function(x) {
   # extra column (at the end) in v2
   ct <- list(
-    Sample = "c", Name = "c", Chr1 = "c", Pos1 = "d", Chr2 = "c",
-    Pos2 = "d", Direction = "c", Alt_Depth = "d", BP1_Depth = "d",
-    BP2_Depth = "d", Total_Depth = "d", VAF = "d", Gene1 = "c", Gene2 = "c",
-    Contig = "c", Filter = "c", Is_Cosmic_GenePair = "l"
+    Sample = "c",
+    Name = "c",
+    Chr1 = "c",
+    Pos1 = "d",
+    Chr2 = "c",
+    Pos2 = "d",
+    Direction = "c",
+    Alt_Depth = "d",
+    BP1_Depth = "d",
+    BP2_Depth = "d",
+    Total_Depth = "d",
+    VAF = "d",
+    Gene1 = "c",
+    Gene2 = "c",
+    Contig = "c",
+    Filter = "c",
+    Is_Cosmic_GenePair = "l"
   )
   ct2 <- list("Fusion Directionality Known" = "c")
   hdr <- readr::read_csv(x, n_max = 0, comment = "#", show_col_types = FALSE)
@@ -418,8 +485,11 @@ tso_msi_read <- function(x) {
     j[["PercentageUnstableSites"]] <- NA_real_
   }
   num_cols <- c(
-    "TotalMicrosatelliteSitesAssessed", "TotalMicrosatelliteSitesUnstable",
-    "PercentageUnstableSites", "SumDistance", "SumJsd"
+    "TotalMicrosatelliteSitesAssessed",
+    "TotalMicrosatelliteSitesUnstable",
+    "PercentageUnstableSites",
+    "SumDistance",
+    "SumJsd"
   )
   tibble::as_tibble_row(j) |>
     dplyr::mutate(

--- a/R/tso_acfc.R
+++ b/R/tso_acfc.R
@@ -28,7 +28,12 @@ tso_acfc_read <- function(x) {
   }
   j <- read_jsongz_rjsonio(x, simplify = FALSE)
   secs <- list(
-    s1 = c("MappingAligningPerRg", "MappingAligningSummary", "TrimmerStatistics", "CoverageSummary"),
+    s1 = c(
+      "MappingAligningPerRg",
+      "MappingAligningSummary",
+      "TrimmerStatistics",
+      "CoverageSummary"
+    ),
     s2 = c("UmiStatistics", "SvSummary", "RunTime")
   )
   s1_new <- c(
@@ -51,11 +56,19 @@ tso_acfc_read <- function(x) {
     if (sec %in% names(d)) {
       new_nm <- s1_new[sec]
       d[[new_nm]] <- d[[sec]] |>
-        tidyr::pivot_longer(cols = c("value", "percent"), names_to = "name1", values_to = "value1") |>
+        tidyr::pivot_longer(
+          cols = c("value", "percent"),
+          names_to = "name1",
+          values_to = "value1"
+        ) |>
         dplyr::filter(!is.na(.data$value1)) |>
         dplyr::mutate(
           value = as.numeric(.data$value1),
-          name = dplyr::if_else(.data$name1 == "percent", paste0(.data$name, " pct"), .data$name)
+          name = dplyr::if_else(
+            .data$name1 == "percent",
+            paste0(.data$name, " pct"),
+            .data$name
+          )
         ) |>
         dplyr::select("name", "value") |>
         tidyr::pivot_wider(names_from = "name", values_from = "value") |>
@@ -69,11 +82,19 @@ tso_acfc_read <- function(x) {
     # handle non-hist data
     d[["acfc_umistats"]] <- d[["UmiStatistics"]] |>
       dplyr::filter(!grepl("Hist", .data$name)) |>
-      tidyr::pivot_longer(cols = c("value", "percent"), names_to = "name1", values_to = "value1") |>
+      tidyr::pivot_longer(
+        cols = c("value", "percent"),
+        names_to = "name1",
+        values_to = "value1"
+      ) |>
       dplyr::filter(!is.na(.data$value1)) |>
       dplyr::mutate(
         value = as.numeric(.data$value1),
-        name = dplyr::if_else(.data$name1 == "percent", paste0(.data$name, " pct"), .data$name)
+        name = dplyr::if_else(
+          .data$name1 == "percent",
+          paste0(.data$name, " pct"),
+          .data$name
+        )
       ) |>
       dplyr::select("name", "value") |>
       tidyr::pivot_wider(names_from = "name", values_from = "value") |>
@@ -174,7 +195,9 @@ tso_acfc_plot <- function(d, max_num = 15) {
       labels = scales::label_number(scale_cut = scales::cut_short_scale())
     ) +
     ggplot2::theme_bw() +
-    ggplot2::labs(title = "Number of positions with 0/1/2/3... UMI sequences.") +
+    ggplot2::labs(
+      title = "Number of positions with 0/1/2/3... UMI sequences."
+    ) +
     ggplot2::xlab("Positions") +
     ggplot2::ylab("UMI Sequences")
   list(

--- a/R/tso_sar.R
+++ b/R/tso_sar.R
@@ -37,7 +37,12 @@ tso_sar_read <- function(x) {
     # edge case
     sw_nl_data_sources <- c("name", "version", "description", "releaseDate") |>
       empty_tbl()
-    sw_nl_rest <- c("instanceName", "nirvanaSoftwareVersion", "genomeAssembly", "refseqVersion") |>
+    sw_nl_rest <- c(
+      "instanceName",
+      "nirvanaSoftwareVersion",
+      "genomeAssembly",
+      "refseqVersion"
+    ) |>
       empty_tbl()
   }
   sw_conf[["nirvanaVersionList"]] <- NULL
@@ -74,11 +79,15 @@ tso_sar_read <- function(x) {
       tidyr::pivot_wider(names_from = "name", values_from = "value") |>
       as.list()
     assertthat::assert_that(
-      all(c("CodingRegionSizeMb", "SomaticCodingVariantsCount") %in% names(amet))
+      all(
+        c("CodingRegionSizeMb", "SomaticCodingVariantsCount") %in% names(amet)
+      )
     )
     biom_list[["tmb_per_mb"]] <- tmb[["tumorMutationalBurdenPerMegabase"]]
     biom_list[["tmb_coding_region_sizemb"]] <- amet[["CodingRegionSizeMb"]]
-    biom_list[["tmb_somatic_coding_variants_count"]] <- amet[["SomaticCodingVariantsCount"]]
+    biom_list[["tmb_somatic_coding_variants_count"]] <- amet[[
+      "SomaticCodingVariantsCount"
+    ]]
   }
   biom_tbl <- tibble::as_tibble_row(biom_list)
   empty_tbl2 <- function(cnames) {
@@ -125,11 +134,35 @@ tso_sar_read <- function(x) {
   snvs <- tso_sar_snv(dat[["variants"]][["smallVariants"]])
   if (nrow(snvs) == 0) {
     snvs <- c(
-      "chrom", "pos", "ref", "alt", "af", "qual", "dp_tot", "dp_alt",
-      "transcript", "source", "bioType", "aminoAcids", "cdnaPos", "codons",
-      "cdsPos", "exons", "geneId", "hgnc", "hgvsc", "hgvsp", "isCanonical",
-      "polyPhenScore", "polyPhenPrediction", "proteinId", "proteinPos",
-      "siftScore", "siftPrediction", "consequence", "introns"
+      "chrom",
+      "pos",
+      "ref",
+      "alt",
+      "af",
+      "qual",
+      "dp_tot",
+      "dp_alt",
+      "transcript",
+      "source",
+      "bioType",
+      "aminoAcids",
+      "cdnaPos",
+      "codons",
+      "cdsPos",
+      "exons",
+      "geneId",
+      "hgnc",
+      "hgvsc",
+      "hgvsp",
+      "isCanonical",
+      "polyPhenScore",
+      "polyPhenPrediction",
+      "proteinId",
+      "proteinPos",
+      "siftScore",
+      "siftPrediction",
+      "consequence",
+      "introns"
     ) |>
       empty_tbl2()
   }
@@ -138,8 +171,13 @@ tso_sar_read <- function(x) {
     dplyr::bind_rows()
   if (nrow(cnvs) == 0) {
     cnvs <- c(
-      "foldChange", "qual", "copyNumberType", "gene", "chromosome",
-      "startPosition", "endPosition"
+      "foldChange",
+      "qual",
+      "copyNumberType",
+      "gene",
+      "chromosome",
+      "startPosition",
+      "endPosition"
     ) |>
       empty_tbl2()
   }

--- a/R/tsov2.R
+++ b/R/tsov2.R
@@ -89,33 +89,22 @@ Wf_cttsov2 <- R6::R6Class(
         prefix = glue("{dc}/{prefix}")
       )
       # Results
+      # fmt: skip
       regexes <- tibble::tribble(
-        ~regex,
-        ~fun,
-        glue("{res}/{pref}\\.cnv\\.vcf\\.gz$"),
-        "read_cnv",
-        glue("{res}/{pref}\\.cnv\\.vcf\\.gz\\.tbi$"),
-        "DOWNLOAD_ONLY-cnvvcfi",
-        glue("{res}/{pref}\\.exon_cov_report\\.tsv$"),
-        "read_cvgrepe",
-        glue("{res}/{pref}\\.gene_cov_report\\.tsv$"),
-        "read_cvgrepg",
-        glue("{res}/{pref}\\.hard-filtered\\.vcf\\.gz$"),
-        "read_hardfilt",
-        glue("{res}/{pref}\\.hard-filtered\\.vcf\\.gz\\.tbi$"),
-        "DOWNLOAD_ONLY-hardfiltvcfi",
+        ~regex, ~fun,
+        glue("{res}/{pref}\\.cnv\\.vcf\\.gz$"), "read_cnv",
+        glue("{res}/{pref}\\.cnv\\.vcf\\.gz\\.tbi$"), "DOWNLOAD_ONLY-cnvvcfi",
+        glue("{res}/{pref}\\.exon_cov_report\\.tsv$"), "read_cvgrepe",
+        glue("{res}/{pref}\\.gene_cov_report\\.tsv$"), "read_cvgrepg",
+        glue("{res}/{pref}\\.hard-filtered\\.vcf\\.gz$"), "read_hardfilt",
+        glue("{res}/{pref}\\.hard-filtered\\.vcf\\.gz\\.tbi$"), "DOWNLOAD_ONLY-hardfiltvcfi",
         # glue("{res}/{pref}\\.microsat_output\\.json$"), "msi", # in DragenCaller
-        glue("{res}/{pref}\\.tmb.trace\\.tsv$"),
-        "read_tmbt",
-        glue("{res}/{pref}_CombinedVariantOutput\\.tsv$"),
-        "read_cvo",
-        glue("{res}/{pref}_Fusions\\.csv$"),
-        "read_fus",
-        glue("{res}/{pref}_MetricsOutput\\.tsv$"),
-        "DOWNLOAD_ONLY-metricsoutput",
+        glue("{res}/{pref}\\.tmb.trace\\.tsv$"), "read_tmbt",
+        glue("{res}/{pref}_CombinedVariantOutput\\.tsv$"), "read_cvo",
+        glue("{res}/{pref}_Fusions\\.csv$"), "read_fus",
+        glue("{res}/{pref}_MetricsOutput\\.tsv$"), "DOWNLOAD_ONLY-metricsoutput",
         # glue("{res}/{pref}_SmallVariants_Annotated\\.json\\.gz$"), "DOWNLOAD_ONLY-smallvannjson",
-        glue("{li}/SampleAnalysisResults/{pref}_SampleAnalysisResults\\.json$"),
-        "read_sar"
+        glue("{li}/SampleAnalysisResults/{pref}_SampleAnalysisResults\\.json$"), "read_sar"
       )
       super$initialize(path = path, wname = wname, regexes = regexes)
       self$prefix <- prefix
@@ -123,17 +112,13 @@ Wf_cttsov2 <- R6::R6Class(
     #' @description Print details about the Workflow.
     #' @param ... (ignored).
     print = function(...) {
+      # fmt: skip
       res <- tibble::tribble(
-        ~var,
-        ~value,
-        "path",
-        private$.path,
-        "wname",
-        private$.wname,
-        "filesystem",
-        private$.filesystem,
-        "prefix",
-        self$prefix
+        ~var, ~value,
+        "path", private$.path,
+        "wname", private$.wname,
+        "filesystem", private$.filesystem,
+        "prefix", self$prefix
       )
       print(res)
       invisible(self)

--- a/R/tsov2.R
+++ b/R/tsov2.R
@@ -84,23 +84,38 @@ Wf_cttsov2 <- R6::R6Class(
       li <- "Logs_Intermediates"
       dc <- glue("{li}/DragenCaller/{pref}")
       path <- sub("/$", "", path) # remove potential trailing slash
-      self$dragenObj <- Wf_dragen$new(path = file.path(path, dc), prefix = glue("{dc}/{prefix}"))
+      self$dragenObj <- Wf_dragen$new(
+        path = file.path(path, dc),
+        prefix = glue("{dc}/{prefix}")
+      )
       # Results
       regexes <- tibble::tribble(
-        ~regex, ~fun,
-        glue("{res}/{pref}\\.cnv\\.vcf\\.gz$"), "read_cnv",
-        glue("{res}/{pref}\\.cnv\\.vcf\\.gz\\.tbi$"), "DOWNLOAD_ONLY-cnvvcfi",
-        glue("{res}/{pref}\\.exon_cov_report\\.tsv$"), "read_cvgrepe",
-        glue("{res}/{pref}\\.gene_cov_report\\.tsv$"), "read_cvgrepg",
-        glue("{res}/{pref}\\.hard-filtered\\.vcf\\.gz$"), "read_hardfilt",
-        glue("{res}/{pref}\\.hard-filtered\\.vcf\\.gz\\.tbi$"), "DOWNLOAD_ONLY-hardfiltvcfi",
+        ~regex,
+        ~fun,
+        glue("{res}/{pref}\\.cnv\\.vcf\\.gz$"),
+        "read_cnv",
+        glue("{res}/{pref}\\.cnv\\.vcf\\.gz\\.tbi$"),
+        "DOWNLOAD_ONLY-cnvvcfi",
+        glue("{res}/{pref}\\.exon_cov_report\\.tsv$"),
+        "read_cvgrepe",
+        glue("{res}/{pref}\\.gene_cov_report\\.tsv$"),
+        "read_cvgrepg",
+        glue("{res}/{pref}\\.hard-filtered\\.vcf\\.gz$"),
+        "read_hardfilt",
+        glue("{res}/{pref}\\.hard-filtered\\.vcf\\.gz\\.tbi$"),
+        "DOWNLOAD_ONLY-hardfiltvcfi",
         # glue("{res}/{pref}\\.microsat_output\\.json$"), "msi", # in DragenCaller
-        glue("{res}/{pref}\\.tmb.trace\\.tsv$"), "read_tmbt",
-        glue("{res}/{pref}_CombinedVariantOutput\\.tsv$"), "read_cvo",
-        glue("{res}/{pref}_Fusions\\.csv$"), "read_fus",
-        glue("{res}/{pref}_MetricsOutput\\.tsv$"), "DOWNLOAD_ONLY-metricsoutput",
+        glue("{res}/{pref}\\.tmb.trace\\.tsv$"),
+        "read_tmbt",
+        glue("{res}/{pref}_CombinedVariantOutput\\.tsv$"),
+        "read_cvo",
+        glue("{res}/{pref}_Fusions\\.csv$"),
+        "read_fus",
+        glue("{res}/{pref}_MetricsOutput\\.tsv$"),
+        "DOWNLOAD_ONLY-metricsoutput",
         # glue("{res}/{pref}_SmallVariants_Annotated\\.json\\.gz$"), "DOWNLOAD_ONLY-smallvannjson",
-        glue("{li}/SampleAnalysisResults/{pref}_SampleAnalysisResults\\.json$"), "read_sar"
+        glue("{li}/SampleAnalysisResults/{pref}_SampleAnalysisResults\\.json$"),
+        "read_sar"
       )
       super$initialize(path = path, wname = wname, regexes = regexes)
       self$prefix <- prefix
@@ -109,11 +124,16 @@ Wf_cttsov2 <- R6::R6Class(
     #' @param ... (ignored).
     print = function(...) {
       res <- tibble::tribble(
-        ~var, ~value,
-        "path", private$.path,
-        "wname", private$.wname,
-        "filesystem", private$.filesystem,
-        "prefix", self$prefix
+        ~var,
+        ~value,
+        "path",
+        private$.path,
+        "wname",
+        private$.wname,
+        "filesystem",
+        private$.filesystem,
+        "prefix",
+        self$prefix
       )
       print(res)
       invisible(self)
@@ -145,9 +165,14 @@ Wf_cttsov2 <- R6::R6Class(
     #' @param x Path to file.
     read_cvgrepe = function(x) {
       ctypes <- list(
-        chr = "c", start = "d", end = "d", gene = "c",
-        mean_coverage = "d", median_coverage = "d",
-        min_coverage = "d", max_coverage = "d"
+        chr = "c",
+        start = "d",
+        end = "d",
+        gene = "c",
+        mean_coverage = "d",
+        median_coverage = "d",
+        min_coverage = "d",
+        max_coverage = "d"
       )
       dat <- x |>
         readr::read_tsv(col_types = ctypes)
@@ -157,8 +182,13 @@ Wf_cttsov2 <- R6::R6Class(
     #' @param x Path to file.
     read_cvgrepg = function(x) {
       ctypes <- list(
-        chr = "c", start = "d", end = "d", gene = "c",
-        mean_coverage = "d", min_coverage = "d", max_coverage = "d"
+        chr = "c",
+        start = "d",
+        end = "d",
+        gene = "c",
+        mean_coverage = "d",
+        min_coverage = "d",
+        max_coverage = "d"
       )
       dat <- x |>
         readr::read_tsv(col_types = ctypes)
@@ -228,17 +258,25 @@ Wf_cttsov2 <- R6::R6Class(
 #' )
 #' }
 #' @export
-dtw_Wf_cttsov2 <- function(path, prefix, outdir,
-                           outdir_tidy = file.path(outdir, "dracarys_tidy"),
-                           format = "rds",
-                           max_files = 1000,
-                           dryrun = FALSE) {
+dtw_Wf_cttsov2 <- function(
+  path,
+  prefix,
+  outdir,
+  outdir_tidy = file.path(outdir, "dracarys_tidy"),
+  format = "rds",
+  max_files = 1000,
+  dryrun = FALSE
+) {
   obj <- Wf_cttsov2$new(path = path, prefix = prefix)
   d_dl1 <- obj$download_files(
-    outdir = outdir, max_files = max_files, dryrun = dryrun
+    outdir = outdir,
+    max_files = max_files,
+    dryrun = dryrun
   )
   d_dl2 <- obj$dragenObj$download_files(
-    outdir = outdir, max_files = max_files, dryrun = dryrun
+    outdir = outdir,
+    max_files = max_files,
+    dryrun = dryrun
   )
   if (!dryrun) {
     d_tidy1 <- obj$tidy_files(d_dl1)

--- a/R/umccrise.R
+++ b/R/umccrise.R
@@ -45,11 +45,16 @@ Wf_umccrise <- R6::R6Class(
     #' @param SubjectID The SubjectID of the sample.
     #' @param SampleID_tumor The SampleID of the tumor sample.
     #' @param SampleID_normal The SampleID of the normal sample.
-    initialize = function(path = NULL, SubjectID = NULL,
-                          SampleID_tumor = NULL, SampleID_normal = NULL) {
+    initialize = function(
+      path = NULL,
+      SubjectID = NULL,
+      SampleID_tumor = NULL,
+      SampleID_normal = NULL
+    ) {
       wname <- "umccrise"
       pref <- glue("{SubjectID}__{SampleID_tumor}")
       crep <- "cancer_report_tables"
+      # fmt: skip
       regexes <- tibble::tribble(
         ~regex, ~fun,
         glue("{path}/{pref}/{crep}/hrd/{pref}-chord\\.tsv\\.gz$"), "read_hrdChord",
@@ -78,6 +83,7 @@ Wf_umccrise <- R6::R6Class(
     #' @description Print details about the Workflow.
     #' @param ... (ignored).
     print = function(...) {
+      # fmt: skip
       res <- tibble::tribble(
         ~var, ~value,
         "path", private$.path,
@@ -151,29 +157,55 @@ Wf_umccrise <- R6::R6Class(
         tidyr::pivot_wider(names_from = "variable", values_from = "value") |>
         dplyr::rename(MSI_mb_tmp = "MSI (indels/Mb)") |>
         dplyr::mutate(
-          purity_hmf = sub("(.*) \\(.*\\)", "\\1", .data$Purity) |> as.numeric(),
-          ploidy_hmf = sub("(.*) \\(.*\\)", "\\1", .data$Ploidy) |> as.numeric(),
-          hrd_chord = sub("CHORD: (.*); HRDetect: (.*)", "\\1", .data$HRD) |> as.numeric(),
+          purity_hmf = sub("(.*) \\(.*\\)", "\\1", .data$Purity) |>
+            as.numeric(),
+          ploidy_hmf = sub("(.*) \\(.*\\)", "\\1", .data$Ploidy) |>
+            as.numeric(),
+          hrd_chord = sub("CHORD: (.*); HRDetect: (.*)", "\\1", .data$HRD) |>
+            as.numeric(),
           hrd_hrdetect = sub("CHORD: (.*); HRDetect: (.*)", "\\2", .data$HRD),
           # handle HRDetect NA
-          hrd_hrdetect = ifelse(.data$hrd_hrdetect == "NA", NA_real_, as.numeric(.data$hrd_hrdetect)),
-          msi_mb_hmf = sub(".* \\((.*)\\)", "\\1", .data$MSI_mb_tmp) |> as.numeric(),
+          hrd_hrdetect = ifelse(
+            .data$hrd_hrdetect == "NA",
+            NA_real_,
+            as.numeric(.data$hrd_hrdetect)
+          ),
+          msi_mb_hmf = sub(".* \\((.*)\\)", "\\1", .data$MSI_mb_tmp) |>
+            as.numeric(),
           contamination_hmf = as.numeric(.data$Contamination),
           deleted_genes_hmf = as.numeric(.data$DeletedGenes),
           msi_hmf = sub("(.*) \\(.*\\)", "\\1", .data$MSI_mb_tmp),
           tmb_hmf = sub("(.*) \\(.*\\)", "\\1", .data$TMB) |> as.numeric(),
           tml_hmf = sub("(.*) \\(.*\\)", "\\1", .data$TML) |> as.numeric(),
-          hypermutated = ifelse("Hypermutated" %in% d$variable, .data[["Hypermutated"]], NA) |> as.character(),
-          bpi_enabled = ifelse("BPI Enabled" %in% d$variable, .data[["BPI Enabled"]], NA) |> as.character(),
+          hypermutated = ifelse(
+            "Hypermutated" %in% d$variable,
+            .data[["Hypermutated"]],
+            NA
+          ) |>
+            as.character(),
+          bpi_enabled = ifelse(
+            "BPI Enabled" %in% d$variable,
+            .data[["BPI Enabled"]],
+            NA
+          ) |>
+            as.character(),
         ) |>
         dplyr::select(
           qc_status_hmf = "QC_Status",
           sex_hmf = "Gender",
-          "purity_hmf", "ploidy_hmf", "msi_hmf", "msi_mb_hmf",
-          "hrd_chord", "hrd_hrdetect", "contamination_hmf",
-          "deleted_genes_hmf", "tmb_hmf", "tml_hmf",
+          "purity_hmf",
+          "ploidy_hmf",
+          "msi_hmf",
+          "msi_mb_hmf",
+          "hrd_chord",
+          "hrd_hrdetect",
+          "contamination_hmf",
+          "deleted_genes_hmf",
+          "tmb_hmf",
+          "tml_hmf",
           wgd_hmf = "WGD",
-          "hypermutated", "bpi_enabled"
+          "hypermutated",
+          "bpi_enabled"
         )
       tibble::tibble(name = glue("qcsum"), data = list(dat[]))
     },
@@ -181,18 +213,30 @@ Wf_umccrise <- R6::R6Class(
     #' @param x Path to file.
     read_conpair = function(x) {
       um_ref_samples <- c("Alice", "Bob", "Chen", "Elon", "Dakota")
-      um_ref_samples <- paste0(um_ref_samples, rep(c("_T", "_B", ""), each = length(um_ref_samples)))
+      um_ref_samples <- paste0(
+        um_ref_samples,
+        rep(c("_T", "_B", ""), each = length(um_ref_samples))
+      )
       cnames <- list(
         old = c(
-          "Sample", "concordance_concordance", "concordance_used_markers",
-          "concordance_total_markers", "concordance_marker_threshold",
-          "concordance_min_mapping_quality", "concordance_min_base_quality",
+          "Sample",
+          "concordance_concordance",
+          "concordance_used_markers",
+          "concordance_total_markers",
+          "concordance_marker_threshold",
+          "concordance_min_mapping_quality",
+          "concordance_min_base_quality",
           "contamination"
         ),
         new = c(
-          "sampleid", "contamination", "concordance", "markers_used",
-          "markers_total", "marker_threshold",
-          "mapq_min", "baseq_min"
+          "sampleid",
+          "contamination",
+          "concordance",
+          "markers_used",
+          "markers_total",
+          "marker_threshold",
+          "mapq_min",
+          "baseq_min"
         )
       )
       ctypes <- list(
@@ -202,7 +246,10 @@ Wf_umccrise <- R6::R6Class(
       if (!file.exists(x)) {
         return(empty_tbl(cnames$new, ctypes$new))
       }
-      d1 <- readr::read_tsv(x, col_types = readr::cols(.default = "d", Sample = "c"))
+      d1 <- readr::read_tsv(
+        x,
+        col_types = readr::cols(.default = "d", Sample = "c")
+      )
       assertthat::assert_that(all(colnames(d1) == cnames$old))
       dat <- d1 |>
         dplyr::filter(!.data$Sample %in% um_ref_samples) |>
@@ -245,16 +292,26 @@ Wf_umccrise <- R6::R6Class(
 #' )
 #' }
 #' @export
-Wf_umccrise_download_tidy_write <- function(path, SubjectID,
-                                            SampleID_tumor, SampleID_normal,
-                                            outdir, format = "rds", max_files = 1000,
-                                            dryrun = FALSE) {
+Wf_umccrise_download_tidy_write <- function(
+  path,
+  SubjectID,
+  SampleID_tumor,
+  SampleID_normal,
+  outdir,
+  format = "rds",
+  max_files = 1000,
+  dryrun = FALSE
+) {
   um <- Wf_umccrise$new(
-    path = path, SubjectID = SubjectID,
-    SampleID_tumor = SampleID_tumor, SampleID_normal = SampleID_normal
+    path = path,
+    SubjectID = SubjectID,
+    SampleID_tumor = SampleID_tumor,
+    SampleID_normal = SampleID_normal
   )
   d_dl <- um$download_files(
-    outdir = outdir, max_files = max_files, dryrun = dryrun
+    outdir = outdir,
+    max_files = max_files,
+    dryrun = dryrun
   )
   if (!dryrun) {
     d_tidy <- um$tidy_files(d_dl)

--- a/R/utils.R
+++ b/R/utils.R
@@ -50,7 +50,9 @@ session_info_tbls <- function(pkgs = NULL) {
     dplyr::as_tibble() |>
     dplyr::select(
       "package",
-      version = "ondiskversion", datestamp = "date", "source"
+      version = "ondiskversion",
+      datestamp = "date",
+      "source"
     )
   if (!is.null(pkgs)) {
     si_pkg <- si_pkg |>
@@ -73,7 +75,8 @@ dr_output_format_valid <- function(x) {
     is.null(x) | all(x %in% format_choices),
     msg = paste0(
       "Output format should be one or more of ",
-      paste(format_choices, collapse = ", "), ", or _only_ NULL."
+      paste(format_choices, collapse = ", "),
+      ", or _only_ NULL."
     )
   )
 }
@@ -142,7 +145,13 @@ write_dracarys <- function(obj, prefix, out_format, drid = NULL) {
 #'
 #' @return Tibble with nested objects that have been written to the output directory.
 #' @export
-write_dracarys_list_of_tbls <- function(list_of_tbls, out_dir = NULL, prefix = NULL, out_format = "tsv", drid = NULL) {
+write_dracarys_list_of_tbls <- function(
+  list_of_tbls,
+  out_dir = NULL,
+  prefix = NULL,
+  out_format = "tsv",
+  drid = NULL
+) {
   assertthat::assert_that(!is.null(prefix))
   if (!is.null(out_dir)) {
     prefix <- file.path(out_dir, prefix)
@@ -153,7 +162,12 @@ write_dracarys_list_of_tbls <- function(list_of_tbls, out_dir = NULL, prefix = N
     dplyr::mutate(
       section_low = tolower(.data$section),
       p = glue("{prefix}_{.data$section_low}"),
-      out = list(write_dracarys(obj = .data$value, prefix = .data$p, out_format = out_format, drid = drid))
+      out = list(write_dracarys(
+        obj = .data$value,
+        prefix = .data$p,
+        out_format = out_format,
+        drid = drid
+      ))
     ) |>
     dplyr::ungroup() |>
     dplyr::select("section", "value") |>

--- a/R/vcf.R
+++ b/R/vcf.R
@@ -20,7 +20,10 @@ bcftools_installed <- function() {
 #' @export
 bcftools_parse_vcf <- function(vcf, only_pass = TRUE, alias = TRUE) {
   assertthat::assert_that(is.logical(only_pass), length(only_pass) == 1)
-  assertthat::assert_that(bcftools_installed(), msg = "bcftools needs to be on the PATH.")
+  assertthat::assert_that(
+    bcftools_installed(),
+    msg = "bcftools needs to be on the PATH."
+  )
   if (is_url(vcf)) {
     vcf <- glue("'{vcf}'")
   }
@@ -35,7 +38,8 @@ bcftools_parse_vcf <- function(vcf, only_pass = TRUE, alias = TRUE) {
       msg <- paste(c(main, "INFO", "FORMAT"), collapse = ", ")
       stop(
         "What on earth. Check that your VCF has the following VCF columns, followed by sample columns:\n",
-        msg, "\nCall me if everything seems fine on 1800-OMG-LOL."
+        msg,
+        "\nCall me if everything seems fine on 1800-OMG-LOL."
       )
     }
     samples <- x[-(1:main_len)]
@@ -58,7 +62,12 @@ bcftools_parse_vcf <- function(vcf, only_pass = TRUE, alias = TRUE) {
       tibble::as_tibble_col(column_name = "x") |>
       dplyr::mutate(x = sub(pat, "", .data$x)) |>
       # Description is likely to have a comma
-      tidyr::separate_wider_delim("x", delim = ",", names = c("ID", "Number", "Type", "Description"), too_many = "merge") |>
+      tidyr::separate_wider_delim(
+        "x",
+        delim = ",",
+        names = c("ID", "Number", "Type", "Description"),
+        too_many = "merge"
+      ) |>
       dplyr::mutate(
         ID = sub("ID=", "", .data$ID),
         Number = sub("Number=", "", .data$Number),
@@ -87,7 +96,12 @@ bcftools_parse_vcf <- function(vcf, only_pass = TRUE, alias = TRUE) {
   )
   # handle empty VCF - fread warns about size 0
   suppressWarnings({
-    first_row <- data.table::fread(cmd = cmd_body, sep = "\t", na.strings = ".", nrows = 1)
+    first_row <- data.table::fread(
+      cmd = cmd_body,
+      sep = "\t",
+      na.strings = ".",
+      nrows = 1
+    )
   })
   if (nrow(first_row) == 0) {
     return(empty_tbl(cnames = cnames))
@@ -125,7 +139,10 @@ bcftools_parse_vcf <- function(vcf, only_pass = TRUE, alias = TRUE) {
 #' @export
 bcftools_parse_vcf_regions <- function(vcf, r, only_pass = TRUE) {
   assertthat::assert_that(is.character(r))
-  assertthat::assert_that(bcftools_installed(), msg = "bcftools needs to be on the PATH.")
+  assertthat::assert_that(
+    bcftools_installed(),
+    msg = "bcftools needs to be on the PATH."
+  )
   if (is_url(vcf)) {
     vcf <- glue("'{vcf}'")
   }

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,8 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+exclude = []
+default-exclude = true

--- a/inst/cli/dracarys.R
+++ b/inst/cli/dracarys.R
@@ -1,5 +1,6 @@
 #!/usr/bin/env Rscript
 
+# fmt: skip file
 suppressPackageStartupMessages(require(argparse, include.only = "ArgumentParser"))
 suppressPackageStartupMessages(require(arrow, include.only = "write_parquet"))
 suppressPackageStartupMessages(require(assertthat, include.only = "assert_that"))

--- a/inst/cli/tidy.R
+++ b/inst/cli/tidy.R
@@ -1,3 +1,4 @@
+# fmt: skip file
 tidy_add_args <- function(subp) {
   tidy <- subp$add_parser("tidy", help = "Tidy UMCCR Workflow Outputs")
   tidy$add_argument("-i", "--in_dir", help = glue("{emoji('snowman')} Directory with untidy UMCCR workflow results. Can be S3 or local."), required = TRUE)


### PR DESCRIPTION
Resolves #162.
Need to skip formatting for tribbles with `# fmt: skip`.

- Binary is installed via Positron at `~/.positron/extensions/posit.air-vscode-0.8.0-darwin-arm64/bundled/bin/air`
- Commands used:
  - `air format file.R`
  - `air format folder/`

For pre-commit hook implementation see issue 269 at https://github.com/posit-dev/air.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build configurations to prevent unwanted files from being included.
  - Disabled an automated style check during pre-commit to streamline the development process.
  - Added a code formatting configuration file with standardized settings.

- **Refactor**
  - Reorganized and reformatted function and method signatures for improved clarity and maintainability.

These internal improvements enhance consistency and streamline our build and development workflow while ensuring that end-user functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->